### PR TITLE
Group Dependabot patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     schedule:
       interval: daily
     groups:
+      patches-and-minors:
+        update-types:
+          - 'patch'
+          - 'minor'
+
       eslint:
         patterns:
           - 'eslint'


### PR DESCRIPTION
I am hoping to reduce the amount of PRs that dependabot opens. I think with this configuration change, we will get one big PR with all of the patch updates at once, which should help things flow a little faster and with less noise for us to deal with.

This has been working well for us in other repos.