### PR TITLE
Fail orchestrate job when curl request fails

### DIFF
--- a/.github/actions/orchestrate-happo/action.yaml
+++ b/.github/actions/orchestrate-happo/action.yaml
@@ -78,7 +78,8 @@ runs:
         echo "Data: ${DATA}"
 
         # Call Happo
-        curl --header "Content-Type: application/json" \
+        curl --fail --silent --show-error \
+          --header "Content-Type: application/json" \
           --request POST \
           --data "${DATA}" \
           -u "${{ inputs.happo-api-key }}:${{ inputs.happo-api-secret }}" \


### PR DESCRIPTION
I had a PR from dependabot that didn't have the screts yet, and this curl request failed but the job passed. I am hoping that these flags will fix that problem.