### PR TITLE
Always upload assets via signed URLs

### DIFF
--- a/src/e2e/__tests__/controller.test.ts
+++ b/src/e2e/__tests__/controller.test.ts
@@ -24,7 +24,10 @@ before(async () => {
     // Set proper headers
     res.setHeader('Content-Type', 'application/json');
 
-    if (req.url?.startsWith('/api/snap-requests/assets-data/')) {
+    if (
+      req.url?.startsWith('/api/snap-requests/assets/') &&
+      req.url?.endsWith('/signed-url')
+    ) {
       res.end(JSON.stringify({ path: '/path/to/asset', uploadedAt: '2021-01-01' }));
       return;
     }


### PR DESCRIPTION
This is more reliable and causes less load for our servers, so I think it is a good time to make it the default.