### PR TITLE
Make beforeSha a non-null env attribute

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -166,10 +166,15 @@ async function handleDefaultCommand(
     );
 
     // Create an async comparison.
-    const asyncComparison = await createAsyncComparison(config, environment, logger);
-
     logger.log(`[HAPPO] Async report URL: ${asyncReport.url}`);
-    logger.log(`[HAPPO] Async comparison URL: ${asyncComparison.compareUrl}`);
+    if (environment.beforeSha !== environment.afterSha) {
+      const asyncComparison = await createAsyncComparison(
+        config,
+        environment,
+        logger,
+      );
+      logger.log(`[HAPPO] Async comparison URL: ${asyncComparison.compareUrl}`);
+    }
   } catch (e) {
     logger.error(e instanceof Error ? e.message : String(e), e);
     const cancelJob = (await import('../network/cancelJob.ts')).default;

--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -247,7 +247,7 @@ describe('resolveEnvironment', () => {
     );
     result = await resolveEnvironment(githubEnv);
     assert.equal(result.afterSha, currentSha);
-    assert.equal(result.beforeSha, undefined);
+    assert.equal(result.beforeSha, currentSha);
     assert.equal(
       result.link,
       `https://github.com/octo-org/octo-repo/commit/${currentSha}`,
@@ -362,7 +362,7 @@ describe('resolveEnvironment', () => {
     });
 
     assert.equal(result.afterSha, currentSha);
-    assert.ok(result.beforeSha === undefined);
+    assert.equal(result.beforeSha, currentSha);
     assert.equal(result.link, 'link://link');
     assert.ok(result.message !== undefined);
 

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -31,7 +31,7 @@ export interface EnvironmentResult {
   link: string | undefined;
   message: string | undefined;
   author: string | undefined;
-  beforeSha: string | undefined;
+  beforeSha: string;
   afterSha: string;
   nonce: string | undefined;
   debugMode: boolean;
@@ -495,16 +495,18 @@ export default async function resolveEnvironment(
     resolveMessage(env, afterShaWithLocalChanges),
   ]);
 
+  const nonNullBeforeSha = beforeSha || afterShaWithLocalChanges;
+
   const result = {
     link,
     author,
     message,
-    beforeSha,
+    beforeSha: nonNullBeforeSha,
     afterSha: afterShaWithLocalChanges,
     nonce: env.HAPPO_NONCE,
     debugMode,
     notify: env.HAPPO_NOTIFY,
-    fallbackShas: resolveFallbackShas(env, beforeSha),
+    fallbackShas: resolveFallbackShas(env, nonNullBeforeSha),
   };
 
   if (debugMode) {

--- a/src/network/createAsyncComparison.ts
+++ b/src/network/createAsyncComparison.ts
@@ -47,6 +47,12 @@ export default async function createAsyncComparison(
   }: EnvironmentResult,
   logger: Logger,
 ): Promise<CreateAsyncComparisonResult> {
+  if (beforeSha === afterSha) {
+    throw new Error(
+      `Cannot create an async comparison between the same SHA (beforeSha=${beforeSha}, afterSha=${afterSha})`,
+    );
+  }
+
   const result = await makeHappoAPIRequest(
     {
       path: `/api/reports/${beforeSha}/compare/${afterSha}`,


### PR DESCRIPTION
I noticed a job I was running tried to post something against /api/reports/undefined/compare/foobar. To make this less likely to happen, I'm defaulting the beforeSha to afterSha. This will reduce the likelyhood of us creating comparisons etc with a faulty beforeSha. To prevent comparisons against equal shas, I'm adding a conditional in createAsyncComparison.