### PR TITLE
Create iframe.html automatically for static integrations

### DIFF
--- a/happoconfigs/happo.static.config.ts
+++ b/happoconfigs/happo.static.config.ts
@@ -7,7 +7,10 @@ const config: Config = defineConfig({
   project: 'static',
   integration: {
     type: 'static',
-    generateStaticPackage: async () => './tmp/happo-static',
+    generateStaticPackage: async () => ({
+      rootDir: './tmp/happo-static',
+      entryPoint: 'bundle.js',
+    }),
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build": "pnpm build:types && pnpm build:dist",
     "build:dist": "./scripts/build.ts",
     "build:types": "pnpm tsc --pretty",
-    "build:static": "esbuild src/static/__happo__/index.ts --bundle --format=iife --global-name=happoStatic --outfile=tmp/happo-static/bundle.js --platform=browser --target=esnext && cp src/static/__happo__/iframe.html tmp/happo-static/",
+    "build:static": "esbuild src/static/__happo__/index.ts --bundle --format=iife --global-name=happoStatic --outfile=tmp/happo-static/bundle.js --platform=browser --target=esnext",
     "build:watch": "tsc --build --watch",
     "clean": "rm -rf dist tmp/tsc tmp/happo-static",
     "lint": "eslint .",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -57,12 +57,14 @@ interface StaticIntegration {
   type: 'static';
 
   /**
-   * An async function that generates a static package. Returns the path to the
-   * folder containing the static files. You can use a prebuilt package (simply
-   * point to the output directory of the Storybook build) or build the package
-   * yourself.
+   * An async function that generates a static package. Returns an object with
+   * the path to the folder containing the static files and the path to the
+   * entry point file relative to the root directory.
+   *
+   * @example
+   * { rootDir: 'dist/static', entryPoint: 'index.js' }
    */
-  generateStaticPackage: () => Promise<string>;
+  generateStaticPackage: () => Promise<{ rootDir: string; entryPoint: string }>;
 }
 
 interface Page {

--- a/src/network/__tests__/makeHappoAPIRequest.test.ts
+++ b/src/network/__tests__/makeHappoAPIRequest.test.ts
@@ -125,7 +125,10 @@ beforeEach(() => {
     project: 'test',
     integration: {
       type: 'static',
-      generateStaticPackage: async () => './static',
+      generateStaticPackage: async () => ({
+        rootDir: './static',
+        entryPoint: 'index.js',
+      }),
     },
     endpoint: 'http://localhost:8990',
     apiKey: 'foo',

--- a/src/static/__happo__/iframe.html
+++ b/src/static/__happo__/iframe.html
@@ -1,8 +1,0 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <script src="/bundle.js"></script>
-  </head>
-  <body></body>
-</html>


### PR DESCRIPTION
So that consumers don't have to worry about this, we'll let them return an object with the path to the output dir plus the name of the entrypoint.