### PR TITLE
Rename browserType to type

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ export default defineConfig({
   apiSecret: process.env.HAPPO_API_SECRET!,
   targets: {
     'chrome-desktop': {
-      browserType: 'chrome',
+      type: 'chrome',
       viewport: '1280x720',
     },
     'firefox-desktop': {
-      browserType: 'firefox',
+      type: 'firefox',
       viewport: '1280x720',
     },
     'ios-safari': {
-      browserType: 'ios-safari',
+      type: 'ios-safari',
     },
   },
 });

--- a/happoconfigs/happo.config.ts
+++ b/happoconfigs/happo.config.ts
@@ -9,17 +9,17 @@ const config: Config = defineConfig({
 
   targets: {
     chrome: {
-      browserType: 'chrome',
+      type: 'chrome',
       viewport: '1024x768',
     },
 
     chromeSmall: {
-      browserType: 'chrome',
+      type: 'chrome',
       viewport: '375x667',
     },
 
     accessibility: {
-      browserType: 'accessibility',
+      type: 'accessibility',
       viewport: '375x667',
     },
   },

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -77,7 +77,7 @@ beforeEach(async () => {
         apiKey: 'test-key',
         apiSecret: 'test-secret',
         targets: {
-          chrome: { browserType: 'chrome', viewport: '1024x768' },
+          chrome: { type: 'chrome', viewport: '1024x768' },
         },
       };
     `,
@@ -146,7 +146,7 @@ describe('main', () => {
         integration: { type: 'cypress' },
         apiKey: 'custom-key',
         apiSecret: 'custom-secret',
-        targets: { firefox: { browserType: 'firefox', viewport: '800x600' } },
+        targets: { firefox: { type: 'firefox', viewport: '800x600' } },
       };`,
       );
 
@@ -165,7 +165,7 @@ describe('main', () => {
         integration: { type: 'cypress' },
         apiKey: 'custom-key',
         apiSecret: 'custom-secret',
-        targets: { firefox: { browserType: 'firefox', viewport: '800x600' } },
+        targets: { firefox: { type: 'firefox', viewport: '800x600' } },
       };`,
       );
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -154,7 +154,7 @@ type DesktopBrowserType = 'chrome' | 'firefox' | 'edge' | 'safari' | 'accessibil
 export type BrowserType = MobileSafariBrowserType | DesktopBrowserType;
 
 interface BaseTarget {
-  browserType: BrowserType;
+  type: BrowserType;
 
   /**
    * Split the target into chunks to be run on multiple workers in parallel
@@ -277,11 +277,11 @@ interface BaseTarget {
 }
 
 interface MobileSafariTarget extends BaseTarget {
-  browserType: MobileSafariBrowserType;
+  type: MobileSafariBrowserType;
 }
 
 interface DesktopTarget extends BaseTarget {
-  browserType: DesktopBrowserType;
+  type: DesktopBrowserType;
 
   /**
    * Set the viewport size for the browser

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -34,7 +34,7 @@ export async function loadConfigFile(
   if (!config.default.targets) {
     config.default.targets = {
       chrome: {
-        browserType: 'chrome',
+        type: 'chrome',
         viewport: '1024x768',
       },
     };

--- a/src/e2e/controller.ts
+++ b/src/e2e/controller.ts
@@ -48,7 +48,7 @@ interface LocalSnapshot {
 interface DynamicTarget {
   name: string;
   viewport: `${number}x${number}`;
-  browserType: BrowserType;
+  type: BrowserType;
 }
 
 interface CSSBlock {
@@ -370,7 +370,7 @@ Docs:
       }
 
       const target = this.happoConfig.targets[name];
-      const remoteTarget = new RemoteBrowserTarget(target.browserType, target);
+      const remoteTarget = new RemoteBrowserTarget(target.type, target);
       const requestIds = await remoteTarget.execute(
         {
           targetName: name,
@@ -596,7 +596,7 @@ Docs:
         typeof target === 'object' &&
         target.name &&
         target.viewport &&
-        target.browserType
+        target.type
       ) {
         if (!this.happoConfig) {
           throw new Error('Happo config not initialized');
@@ -608,7 +608,7 @@ Docs:
           const targetName = target.name;
           const constructedTarget: TargetWithDefaults = {
             viewport: target.viewport,
-            browserType: target.browserType,
+            type: target.type,
             __dynamic: true,
           };
           // add dynamic target

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -109,7 +109,7 @@ export default async function prepareSnapRequests(
         throw new Error(`Target ${name} not found in config`);
       }
       const target = new RemoteBrowserTarget(
-        config.targets[name].browserType,
+        config.targets[name].type,
         config.targets[name],
       );
       const snapRequestIds = await target.execute(


### PR DESCRIPTION
"Browser type" is a bit awkward when some of these are not browsers exactly (i.e. accessibility). It also seems unnecessarily verbose. Maybe we should shorten this to just "type"?