### PR TITLE
Add waitForContent to pages

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -83,6 +83,11 @@ interface Page {
    * it is unique for each page.
    */
   title: string;
+
+  /**
+   * Wait for the content to appear on the page before taking the screenshot.
+   */
+  waitForContent?: string;
 }
 
 interface PagesIntegration {


### PR DESCRIPTION
I was working on updating documentation and noticed we didn't include this option.