### PR TITLE
Use generated afterSha when local changes are stashed

### DIFF
--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -87,6 +87,19 @@ describe('resolveEnvironment', () => {
 
     // Message should be undefined because we are no longer on a single commit
     assert.equal(result3.message, undefined);
+
+    // Add all changes to the index
+    tmpfs.exec('git', ['add', '.']).trim();
+
+    const result4 = await resolveEnvironment({});
+
+    // After SHA should be different because of the local change
+    assert.notEqual(result4.afterSha, afterSha);
+    // Before SHA should be the same because we didn't change the branch
+    assert.equal(result4.beforeSha, beforeSha);
+
+    // Message should be undefined because we are no longer on a single commit
+    assert.equal(result4.message, undefined);
   });
 
   it('resolves the CircleCI environment', async () => {

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -327,7 +327,7 @@ function getHeadShaWithLocalChanges(): {
   }
 
   // Check for local changes
-  const diffRes = spawnSync('git', ['diff'], {
+  const diffRes = spawnSync('git', ['diff', 'HEAD'], {
     encoding: 'utf8',
   });
 


### PR DESCRIPTION
I ran into a confusing thing when working on adding Happo pages tests to the project. When I pushed my first pull request the comparison for the new pages project found a before report associated with the main branch.

https://github.com/happo/happo/pull/263
https://happo.io/a/768/p/2454/compare/ddb309c460d0904724436f2e8699255189e345f2/bca61033ff26e952bd6b9cc51990451ddf7f0a2c?jobId=1948528

It turns out that I was running happo locally and at some point I ran a report while I had all local changes added to the git index. We weren't taking this state into account which made the afterSha resolve to the current HEAD, which was a commit on the main branch.