### PR TITLE
Update happo e2e docs output

### DIFF
--- a/src/e2e/controller.ts
+++ b/src/e2e/controller.ts
@@ -226,12 +226,13 @@ class Controller {
       console.log(
         `
 [HAPPO] Happo is disabled. Here's how to enable it:
-  - Use the \`happo-e2e\` wrapper.
+  - Use the \`happo\` wrapper.
   - Set \`HAPPO_ENABLED=true\`.
 
 Docs:
-  https://docs.happo.io/docs/cypress#usage-with-cypress-run
-  https://docs.happo.io/docs/cypress#usage-with-cypress-open
+  Playwright:     https://docs.happo.io/docs/playwright#usage
+  Cypress (run):  https://docs.happo.io/docs/cypress#usage-with-cypress-run
+  Cypress (open): https://docs.happo.io/docs/cypress#usage-with-cypress-open
       `.trim(),
       );
       return;


### PR DESCRIPTION
This was old and needed to be updated. I also added a link for Playwright.

It would be nice if we auto-detected which one was being used here, but I didn't see an immediately obvious way to do that so I decided to just output both for now.