### PR TITLE
Replace HAPPO_BEFORE_SHA_TAG_MATCHER with --beforeShaTagMatcher

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -109,6 +109,7 @@ Options:
   --authorEmail <email> Email address of the author of the comparison (default: auto-detected from CI environment)
   --currentSha <sha>    Current SHA to use for comparison (default: auto-detected from CI environment)
   --previousSha <sha>   Previous SHA to use for comparison (default: auto-detected from CI environment)
+  --beforeShaTagMatcher <matcher> git tag matcher to use for before SHA resolution
   --fallbackShas <shas> Space-, newline- or comma-separated list of fallback shas for compare calls (default: auto-detected from CI environment)
   --fallbackShasCount <count> Number of fallback shas to use for compare calls (default: 50)
   --githubBase <url>    GitHub base URL to use for comparison (default: GITHUB_SERVER_URL or 'https://github.com')

--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -225,19 +225,24 @@ describe('resolveEnvironment', () => {
     const azureEnv = {
       BUILD_SOURCEVERSION: afterSha,
       BUILD_REPOSITORY_URI: origin,
-      HAPPO_BEFORE_SHA_TAG_MATCHER: 'happo-*',
     };
-    let result = await resolveEnvironment({}, azureEnv);
+    let result = await resolveEnvironment(
+      {
+        beforeShaTagMatcher: 'happo-*',
+      },
+      azureEnv,
+    );
     assert.equal(result.afterSha, afterSha);
     assert.equal(result.beforeSha, tagSha);
 
     // Try with a matcher that doesn't match anything. This should fall back to
     // the base branch.
     result = await resolveEnvironment(
-      {},
+      {
+        beforeShaTagMatcher: 'happo-dobedoo-*',
+      },
       {
         ...azureEnv,
-        HAPPO_BEFORE_SHA_TAG_MATCHER: 'happo-dobedoo-*',
       },
     );
 


### PR DESCRIPTION
This is easier to discover and use.

I see that we mix up the terminology here--sometimes we use before and other times use previous. I'll follow up with a commit that makes that consistent.