### PR TITLE
Remove HAPPO_BUILD_STORYBOOK_COMMAND

### DIFF
--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -7,7 +7,7 @@ import getStorybookBuildCommandParts from './getStorybookBuildCommandParts.ts';
 import getStorybookVersionFromPackageJson from './getStorybookVersionFromPackageJson.ts';
 import type { SkipItems } from './isomorphic/types.ts';
 
-const { HAPPO_DEBUG, HAPPO_STORYBOOK_BUILD_COMMAND } = process.env;
+const { HAPPO_DEBUG } = process.env;
 
 function assertSkippedIsSkipItems(skipped: unknown): asserts skipped is SkipItems {
   if (!Array.isArray(skipped)) {
@@ -22,10 +22,6 @@ function assertSkippedIsSkipItems(skipped: unknown): asserts skipped is SkipItem
 }
 
 function resolveBuildCommandParts() {
-  if (HAPPO_STORYBOOK_BUILD_COMMAND) {
-    return HAPPO_STORYBOOK_BUILD_COMMAND.split(' ');
-  }
-
   const version = getStorybookVersionFromPackageJson();
 
   if (version < 9) {


### PR DESCRIPTION
This was added here:

https://github.com/happo/happo-plugin-storybook/commit/78640cf0

But it is not entirely clear why, and whether it is still useful. So I'm removing it for now to simplify. If it comes back, perhaps it should come back as a config field on the integration instead?