### PR TITLE
Remove --githubBase CLI flag

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -85,10 +85,6 @@ function parseRawArgs(rawArgs: Array<string>) {
       nonce: {
         type: 'string',
       },
-
-      githubBase: {
-        type: 'string',
-      },
     },
 
     allowPositionals: true,
@@ -121,7 +117,6 @@ Options:
   --fallbackShas <shas> Space-, newline- or comma-separated list of fallback shas for compare calls (default: auto-detected from CI environment)
   --fallbackShasCount <count> Number of fallback shas to use for compare calls (default: 50)
   --notify <emails>     One or more (comma-separated) email addresses to notify with results
-  --githubBase <url>    GitHub base URL to use for comparison (default: GITHUB_SERVER_URL or 'https://github.com')
   --nonce <nonce>       Nonce to use for Cypress/Playwright comparison
 
 Examples:

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -38,7 +38,6 @@ interface CLIArgs {
   notify?: string;
   fallbackShas?: string;
   fallbackShasCount?: string;
-  githubBase?: string;
   nonce?: string;
 }
 
@@ -117,19 +116,23 @@ async function resolveLink(
   const {
     BUILD_REPOSITORY_URI,
     BUILD_SOURCEVERSION,
+
+    // https://circleci.com/docs/reference/variables/
     CIRCLE_PROJECT_REPONAME,
     CIRCLE_PROJECT_USERNAME,
+    CIRCLE_PULL_REQUEST,
     CIRCLE_SHA1,
+
     CI_PULL_REQUEST,
 
     // https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
     GITHUB_EVENT_PATH,
-    GITHUB_SERVER_URL,
     GITHUB_SHA,
 
     SYSTEM_PULLREQUEST_PULLREQUESTID,
     SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI,
 
+    // https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
     TRAVIS_COMMIT,
     TRAVIS_PULL_REQUEST,
     TRAVIS_REPO_SLUG,
@@ -171,7 +174,7 @@ async function resolveLink(
     );
   }
 
-  const githubBase = cliArgs.githubBase || GITHUB_SERVER_URL || 'https://github.com';
+  const githubBase = 'https://github.com';
 
   if (TRAVIS_REPO_SLUG && TRAVIS_PULL_REQUEST) {
     return `${githubBase}/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST}`;
@@ -179,6 +182,10 @@ async function resolveLink(
 
   if (TRAVIS_REPO_SLUG && TRAVIS_COMMIT) {
     return `${githubBase}/${TRAVIS_REPO_SLUG}/commit/${TRAVIS_COMMIT}`;
+  }
+
+  if (CIRCLE_PULL_REQUEST) {
+    return CIRCLE_PULL_REQUEST;
   }
 
   if (CIRCLE_PROJECT_USERNAME && CIRCLE_PROJECT_REPONAME && CIRCLE_SHA1) {


### PR DESCRIPTION
I realized that this was only used when determining the link URL for Travis CI. I don't think this is very useful, so I decided to simplify things. The link can still be passed in directly via the `--link` flag. This simplifies the API of our tool a bit, which will make it easier for everyone to use, and for us to maintain.

I also noticed that there is a CIRCLE_PULL_REQUEST env var we can use here, which matches what we do for other CI providers.

At some point it might be nice to refactor this env var soup to something with a bit more structure, where we detect the CI env somehow and then hand things off to a helper for that specific CI provider to resolve these things.

Closes HAP-511