### PR TITLE
Refactor Logger to use node's built-in styleText

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,14 +137,13 @@
   },
   "dependencies": {
     "async-retry": "^1.3.3",
-    "fflate": "^0.8.2",
     "base64-stream": "^1.0.0",
     "empathic": "^2.0.0",
+    "fflate": "^0.8.2",
     "jose": "^6.1.0",
     "mime-types": "^3.0.1",
     "p-all": "^5.0.1",
-    "srcset": "^5.0.2",
-    "supports-color": "^10.2.2"
+    "srcset": "^5.0.2"
   },
   "keywords": [
     "accessibility",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       srcset:
         specifier: ^5.0.2
         version: 5.0.2
-      supports-color:
-        specifier: ^10.2.2
-        version: 10.2.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.36.0
@@ -50,7 +47,7 @@ importers:
         version: 10.0.6(esbuild@0.25.12)(rollup@4.53.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)))(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0))
       '@storybook/react-vite':
         specifier: ^10.0.1
-        version: 10.0.6(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)))(supports-color@10.2.2)(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0))
+        version: 10.0.6(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)))(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0))
       '@types/async-retry':
         specifier: ^1.4.9
         version: 1.4.9
@@ -86,28 +83,28 @@ importers:
         version: 0.25.12
       eslint:
         specifier: ^9.36.0
-        version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+        version: 9.39.1(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-compat:
         specifier: ^6.0.2
-        version: 6.0.2(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 6.0.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-depend:
         specifier: ^1.3.1
         version: 1.3.1
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
-        version: 12.1.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 12.1.1(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-unicorn:
         specifier: ^62.0.0
-        version: 62.0.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 62.0.0(eslint@9.39.1(jiti@2.6.1))
       jiti:
         specifier: ^2.6.0
         version: 2.6.1
       jsdom:
         specifier: ^27.0.0
-        version: 27.1.0(supports-color@10.2.2)
+        version: 27.1.0
       multiparty:
         specifier: ^4.2.3
         version: 4.2.3
@@ -134,7 +131,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.44.1
-        version: 8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+        version: 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
 
 packages:
 
@@ -2325,10 +2322,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  supports-color@10.2.2:
-    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
-    engines: {node: '>=18'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2679,20 +2672,20 @@ snapshots:
 
   '@babel/compat-data@7.28.5': {}
 
-  '@babel/core@7.28.5(supports-color@10.2.2)':
+  '@babel/core@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5(supports-color@10.2.2)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2717,19 +2710,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.27.1(supports-color@10.2.2)':
+  '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@10.2.2)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.27.1(supports-color@10.2.2)
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@10.2.2)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -2756,7 +2749,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
 
-  '@babel/traverse@7.28.5(supports-color@10.2.2)':
+  '@babel/traverse@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
@@ -2764,7 +2757,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2901,17 +2894,17 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      eslint: 9.39.1(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1(supports-color@10.2.2)':
+  '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2928,10 +2921,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1(supports-color@10.2.2)':
+  '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -3145,7 +3138,7 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0))
 
-  '@storybook/react-vite@10.0.6(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)))(supports-color@10.2.2)(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0))':
+  '@storybook/react-vite@10.0.6(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.0)(storybook@10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)))(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.53.0)
@@ -3154,7 +3147,7 @@ snapshots:
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.0
-      react-docgen: 8.0.2(supports-color@10.2.2)
+      react-docgen: 8.0.2
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.11
       storybook: 10.0.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0))
@@ -3290,15 +3283,15 @@ snapshots:
       '@types/node': 24.10.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.3
-      '@typescript-eslint/type-utils': 8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.3
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      eslint: 9.39.1(jiti@2.6.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -3307,23 +3300,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.3
       '@typescript-eslint/types': 8.46.3
-      '@typescript-eslint/typescript-estree': 8.46.3(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.3
-      debug: 4.4.3(supports-color@10.2.2)
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.46.3(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.46.3(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.3
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3337,13 +3330,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.3
-      '@typescript-eslint/typescript-estree': 8.46.3(supports-color@10.2.2)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.2.2)
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3351,13 +3344,13 @@ snapshots:
 
   '@typescript-eslint/types@8.46.3': {}
 
-  '@typescript-eslint/typescript-estree@8.46.3(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.46.3(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.46.3(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.3
       '@typescript-eslint/visitor-keys': 8.46.3
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -3367,13 +3360,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.46.3
       '@typescript-eslint/types': 8.46.3
-      '@typescript-eslint/typescript-estree': 8.46.3(supports-color@10.2.2)(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3734,12 +3727,6 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
-  debug@4.4.3(supports-color@10.2.2):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
-
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -3852,17 +3839,17 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
+  eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      eslint: 9.39.1(jiti@2.6.1)
 
-  eslint-plugin-compat@6.0.2(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
+  eslint-plugin-compat@6.0.2(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@mdn/browser-compat-data': 5.7.6
       ast-metadata-inferer: 0.8.1
       browserslist: 4.26.2
       caniuse-lite: 1.0.30001743
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      eslint: 9.39.1(jiti@2.6.1)
       find-up: 5.0.0
       globals: 15.15.0
       lodash.memoize: 4.1.2
@@ -3874,20 +3861,20 @@ snapshots:
       module-replacements: 2.9.0
       semver: 7.7.2
 
-  eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
+  eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      eslint: 9.39.1(jiti@2.6.1)
 
-  eslint-plugin-unicorn@62.0.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
+  eslint-plugin-unicorn@62.0.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
       '@eslint/plugin-kit': 0.4.0
       change-case: 5.4.4
       ci-info: 4.3.1
       clean-regexp: 1.0.0
       core-js-compat: 3.46.0
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      eslint: 9.39.1(jiti@2.6.1)
       esquery: 1.6.0
       find-up-simple: 1.0.1
       globals: 16.4.0
@@ -3909,14 +3896,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2):
+  eslint@9.39.1(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1(supports-color@10.2.2)
+      '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.1(supports-color@10.2.2)
+      '@eslint/eslintrc': 3.3.1
       '@eslint/js': 9.39.1
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -3926,7 +3913,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -4182,10 +4169,10 @@ snapshots:
       statuses: 1.5.0
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@10.2.2):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4195,10 +4182,10 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@7.0.6(supports-color@10.2.2):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4284,7 +4271,7 @@ snapshots:
 
   jsbn@0.1.1: {}
 
-  jsdom@27.1.0(supports-color@10.2.2):
+  jsdom@27.1.0:
     dependencies:
       '@acemir/cssom': 0.9.19
       '@asamuzakjp/dom-selector': 6.7.4
@@ -4292,8 +4279,8 @@ snapshots:
       data-urls: 6.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2(supports-color@10.2.2)
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
       saxes: 6.0.0
@@ -4604,10 +4591,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  react-docgen@8.0.2(supports-color@10.2.2):
+  react-docgen@8.0.2:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@10.2.2)
-      '@babel/traverse': 7.28.5(supports-color@10.2.2)
+      '@babel/core': 7.28.5
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -4877,8 +4864,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  supports-color@10.2.2: {}
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4980,13 +4965,13 @@ snapshots:
 
   type-fest@0.8.1: {}
 
-  typescript-eslint@8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3):
+  typescript-eslint@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.46.3(supports-color@10.2.2)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
+      '@typescript-eslint/eslint-plugin': 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,22 +1,11 @@
-import supportsColor from 'supports-color';
+import { styleText } from 'node:util';
 
-// https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color
-
-type ColorFunction = (str: string) => string;
 type PrintFunction = (str: string) => void;
 
-function withColorSupport(wrappedFunc: ColorFunction): ColorFunction {
-  if (supportsColor.stdout && supportsColor.stderr) {
-    return wrappedFunc;
-  }
-  return (msg: string) => msg;
-}
-const red = withColorSupport((str: string) => `\u001B[31m${str}\u001B[0m`);
-const green = withColorSupport((str: string) => `\u001B[32m${str}\u001B[0m`);
-const dim = withColorSupport((str: string) => `\u001B[90m${str}\u001B[0m`);
-const underline = withColorSupport(
-  (str: string) => `\u001B[36m\u001B[4m${str}\u001B[0m`,
-);
+const red = (str: string) => styleText('red', str);
+const green = (str: string) => styleText('green', str);
+const dim = (str: string) => styleText('dim', str);
+const underline = (str: string) => styleText('underline', str);
 
 export function logTag(project?: string): string {
   return project ? `[${project}] ` : '';

--- a/src/utils/__tests__/Logger.test.ts
+++ b/src/utils/__tests__/Logger.test.ts
@@ -1,0 +1,215 @@
+import assert from 'node:assert';
+import type { Mock } from 'node:test';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import Logger, { logTag } from '../Logger.ts';
+
+let subject: () => Logger;
+let stderrPrint: Mock<(str: string) => void>;
+let print: Mock<(str: string) => void>;
+let originalDateNow: typeof Date.now;
+let currentTime: number;
+
+function getCleanLogs(mockedFn: Mock<(str: string) => void>) {
+  return (
+    mockedFn.mock.calls
+      .map((call) => call.arguments[0])
+      .join('')
+      // eslint-disable-next-line no-control-regex
+      .replaceAll(/\u001B\[\d{1,2}m/g, '')
+  );
+}
+
+beforeEach(() => {
+  stderrPrint = mock.fn();
+  print = mock.fn();
+  subject = () => new Logger({ print, stderrPrint });
+
+  // Mock Date.now() for timer tests
+  currentTime = 1000;
+  originalDateNow = Date.now;
+  Date.now = () => currentTime;
+});
+
+afterEach(() => {
+  // Restore Date.now()
+  if (originalDateNow) {
+    Date.now = originalDateNow;
+  }
+});
+
+describe('Logger', () => {
+  it('works without injected printers', () => {
+    // This test is here just to make sure that the dependency injection of the
+    // `print` and `stderrPrint` functions isn't causing any issues
+    const error = new Error('Ignore this log');
+    delete error.stack;
+    new Logger().error(error);
+    new Logger().info('Ignore this log');
+  });
+
+  it('does not print to stdout on errors', () => {
+    subject().error(new Error('foo'));
+    assert.strictEqual(print.mock.calls.length, 0);
+  });
+
+  it('prints to stderr on errors', () => {
+    subject().error(new Error('foo'));
+    assert.strictEqual(stderrPrint.mock.calls.length, 2);
+  });
+
+  it('logs errors with stacks', () => {
+    const error = new Error('damn');
+    error.stack = 'foobar';
+    subject().error(error);
+    // We use `stringContaining` here because the string is wrapped with color
+    // instruction characters
+    assert.ok(
+      stderrPrint.mock.calls[0]?.arguments[0]?.includes('foobar'),
+      'Expected error log to contain stack trace',
+    );
+  });
+
+  it('logs errors without stacks', () => {
+    const error = new Error('damn');
+    delete error.stack;
+    subject().error(error);
+    // We use `stringContaining` here because the string is wrapped with color
+    // instruction characters
+    assert.ok(
+      stderrPrint.mock.calls[0]?.arguments[0]?.includes('damn'),
+      'Expected error log to contain error message',
+    );
+  });
+
+  it('logs "Starting: msg" with start(msg)', () => {
+    const logger = subject();
+
+    logger.start('Pizza');
+    assert.ok(
+      print.mock.calls[0]?.arguments[0]?.includes('Starting: Pizza'),
+      'Expected log to contain "Starting: Pizza"',
+    );
+  });
+
+  it('logs nothing with start()', () => {
+    const logger = subject();
+
+    logger.start();
+    assert.strictEqual(print.mock.calls.length, 0);
+  });
+
+  it('logs start message with success()', () => {
+    const logger = subject();
+
+    logger.start('Pizza');
+    print.mock.resetCalls();
+
+    logger.success('Yum');
+    assert.ok(
+      print.mock.calls[0]?.arguments[0]?.includes('✓'),
+      'Expected log to contain checkmark',
+    );
+    assert.ok(
+      print.mock.calls[1]?.arguments[0]?.includes('Pizza:'),
+      'Expected log to contain "Pizza:"',
+    );
+  });
+
+  it('handles no start message with success()', () => {
+    const logger = subject();
+
+    logger.start();
+    print.mock.resetCalls();
+
+    logger.success('Yum');
+    assert.ok(
+      print.mock.calls[0]?.arguments[0]?.includes('✓'),
+      'Expected log to contain checkmark',
+    );
+  });
+
+  it('logs durations with start() and success()', () => {
+    const logger = subject();
+
+    logger.start('Pizza');
+    assert.ok(
+      print.mock.calls[0]?.arguments[0]?.includes('Starting: Pizza'),
+      'Expected log to contain "Starting: Pizza"',
+    );
+    assert.strictEqual(stderrPrint.mock.calls.length, 0);
+    print.mock.resetCalls();
+
+    currentTime += 12;
+
+    logger.success('Yum');
+    assert.ok(
+      print.mock.calls[2]?.arguments[0]?.includes('Yum'),
+      'Expected log to contain "Yum"',
+    );
+    assert.ok(
+      /\(\d+ms\)/.test(print.mock.calls[3]?.arguments[0] || ''),
+      'Expected log to contain duration in milliseconds',
+    );
+    assert.strictEqual(stderrPrint.mock.calls.length, 0);
+
+    const cleanLogs = getCleanLogs(print);
+    assert.strictEqual(cleanLogs, '✓ Pizza: Yum (12ms)\n');
+  });
+
+  it('logs durations with start() and fail()', () => {
+    const logger = subject();
+
+    logger.start('Pizza');
+    assert.ok(
+      print.mock.calls[0]?.arguments[0]?.includes('Starting: Pizza'),
+      'Expected log to contain "Starting: Pizza"',
+    );
+    assert.strictEqual(stderrPrint.mock.calls.length, 0);
+    print.mock.resetCalls();
+
+    currentTime += 13;
+
+    logger.fail('Yuck');
+    assert.ok(
+      print.mock.calls[2]?.arguments[0]?.includes('Yuck'),
+      'Expected log to contain "Yuck"',
+    );
+    assert.ok(
+      /\(\d+ms\)/.test(print.mock.calls[3]?.arguments[0] || ''),
+      'Expected log to contain duration in milliseconds',
+    );
+    assert.strictEqual(stderrPrint.mock.calls.length, 0);
+
+    const cleanLogs = getCleanLogs(print);
+    assert.strictEqual(cleanLogs, '✗ Pizza: Yuck (13ms)\n');
+  });
+
+  it('logs start message with fail()', () => {
+    const logger = subject();
+
+    logger.start('Pizza');
+    print.mock.resetCalls();
+
+    logger.fail('Yuck');
+    assert.ok(
+      print.mock.calls[0]?.arguments[0]?.includes('✗'),
+      'Expected log to contain X mark',
+    );
+    assert.ok(
+      print.mock.calls[1]?.arguments[0]?.includes(' Pizza:'),
+      'Expected log to contain " Pizza:"',
+    );
+  });
+});
+
+describe('logTag()', () => {
+  it('is empty with no project', () => {
+    assert.strictEqual(logTag(), '');
+    assert.strictEqual(logTag(''), '');
+  });
+
+  it('is [project] with a project', () => {
+    assert.strictEqual(logTag('pizza'), '[pizza] ');
+  });
+});


### PR DESCRIPTION
Documentation here:

https://nodejs.org/docs/latest-v24.x/api/util.html#utilstyletextformat-text-options

This detects whether color is supported or not already, so we can drop the supports-color dependency. Nice!