### PR TITLE
Stop using basename when zipping in-memory content

### DIFF
--- a/src/e2e/__tests__/createAssetPackage.test.ts
+++ b/src/e2e/__tests__/createAssetPackage.test.ts
@@ -47,12 +47,12 @@ describe('createAssetPackage', () => {
     assert.deepEqual(
       entries,
       [
-        '8f037ef4cc4efb6ab6df9cc5d88f7898.jpg',
-        'a0f415163499472aab9e93339b832d12.html',
-        'countries-bg.jpeg',
+        '_external/8f037ef4cc4efb6ab6df9cc5d88f7898.jpg',
+        '_external/a0f415163499472aab9e93339b832d12.html',
+        'sub folder/countries-bg.jpeg',
       ].toSorted(),
     );
-    assert.equal(pkg.hash, '8472953951d24124cd75eacae93db788');
+    assert.equal(pkg.hash, '6bfbf5cafbb71da0dac6bf083bc26a57');
   });
 
   it('includes external assets when downloadAllAssets is true', async () => {
@@ -75,7 +75,10 @@ describe('createAssetPackage', () => {
     assert.equal(entries.length, 2);
     assert.deepEqual(
       entries,
-      ['83112e0c253721ddb1bcff1973e46dcb.png', 'countries-bg.jpeg'].toSorted(),
+      [
+        '_external/83112e0c253721ddb1bcff1973e46dcb.png',
+        'sub folder/countries-bg.jpeg',
+      ].toSorted(),
     );
   });
 });

--- a/src/utils/deterministicArchive.ts
+++ b/src/utils/deterministicArchive.ts
@@ -173,12 +173,11 @@ export default async function deterministicArchive(
   // Process in-memory content
   // Extract basename to match archiver's behavior with prefix: '' for content entries
   for (const file of contentToArchiveSorted) {
-    const zipEntryName = path.basename(file.name);
-    if (!seenFiles.has(zipEntryName)) {
+    if (!seenFiles.has(file.name)) {
       const data = await contentToUint8Array(file.content);
-      entryDataList.push({ name: zipEntryName, data });
-      entries.push({ name: zipEntryName, size: data.length });
-      seenFiles.add(zipEntryName);
+      entryDataList.push({ name: file.name, data });
+      entries.push({ name: file.name, size: data.length });
+      seenFiles.add(file.name);
     }
   }
 


### PR DESCRIPTION
When I replaced archiver with fflate, I made a mistake here and decided to use basename to remove the path from these in-memory files. This is because the test for createAssetPackage was checking the entry.name which was just the basename. But the actual file was in fact stored in the directory. This broke external images in Playwright and Cypress tests.

The fix is to stop using basename, and update the assertions.