### PR TITLE
Replace p-all with limit-concur

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,8 +141,8 @@
     "empathic": "^2.0.0",
     "fflate": "^0.8.2",
     "jose": "^6.1.0",
+    "limit-concur": "^4.0.0",
     "mime-types": "^3.0.1",
-    "p-all": "^5.0.1",
     "srcset": "^5.0.2"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,12 @@ importers:
       jose:
         specifier: ^6.1.0
         version: 6.1.0
+      limit-concur:
+        specifier: ^4.0.0
+        version: 4.0.0
       mime-types:
         specifier: ^3.0.1
         version: 3.0.1
-      p-all:
-        specifier: ^5.0.1
-        version: 5.0.1
       srcset:
         specifier: ^5.0.2
         version: 5.0.2
@@ -1787,6 +1787,10 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  limit-concur@4.0.0:
+    resolution: {integrity: sha512-BXUCP52gLz8JA8/cRKkXswOV6FnA2gl8hL8DbgQuo8XA9NKcwU3Oq/Cg1JyAZ+gyNmFEZXI+ZYLes0BrZkl+7g==}
+    engines: {node: '>= 22'}
+
   listr2@3.14.0:
     resolution: {integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==}
     engines: {node: '>=10.0.0'}
@@ -1950,10 +1954,6 @@ packages:
   ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
 
-  p-all@5.0.1:
-    resolution: {integrity: sha512-LMT7WX9ZSaq3J1zjloApkIVmtz0ZdMFSIqbuiEa3txGYPLjUPOvgOPOx3nFjo+f37ZYL+1aY666I2SG7GVwLOA==}
-    engines: {node: '>=16'}
-
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1965,10 +1965,6 @@ packages:
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
-
-  p-map@6.0.0:
-    resolution: {integrity: sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==}
-    engines: {node: '>=16'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -4334,6 +4330,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  limit-concur@4.0.0: {}
+
   listr2@3.14.0(enquirer@2.4.1):
     dependencies:
       cli-truncate: 2.1.0
@@ -4477,10 +4475,6 @@ snapshots:
 
   ospath@1.2.2: {}
 
-  p-all@5.0.1:
-    dependencies:
-      p-map: 6.0.0
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -4492,8 +4486,6 @@ snapshots:
   p-map@4.0.0:
     dependencies:
       aggregate-error: 3.1.0
-
-  p-map@6.0.0: {}
 
   package-json-from-dist@1.0.1: {}
 

--- a/src/e2e/controller.ts
+++ b/src/e2e/controller.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import pAll from 'p-all';
+import limitConcur from 'limit-concur';
 
 import type {
   BrowserType,
@@ -156,7 +156,9 @@ async function downloadCSSContent(blocks: Array<CSSBlock>): Promise<void> {
     }
   });
 
-  await pAll(actions, { concurrency: 5 });
+  await Promise.all(
+    actions.map(limitConcur(5, (action: () => Promise<void>) => action())),
+  );
 }
 
 class Controller {


### PR DESCRIPTION
I learned about this in the e18e discord. It is a smaller and simpler alternative to p-all and other similar packages.

I followed the recipe in their readme for replacing p-all:

https://github.com/TomerAberbach/limit-concur?tab=readme-ov-file#replacing-p-all