### PR TITLE
Don't use local changes when resolving afterSha in CI

### DIFF
--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -88,6 +88,17 @@ describe('resolveEnvironment', () => {
     // Message should be undefined because we are no longer on a single commit
     assert.equal(result2.message, undefined);
 
+    // Rerun but set `process.env.CI` to `true` to simulate a CI environment
+    const result2InCI = await resolveEnvironment(
+      {},
+      {
+        CI: 'true',
+      },
+    );
+    assert.equal(result2InCI.afterSha, afterSha);
+    assert.equal(result2InCI.beforeSha, beforeSha);
+    assert.notEqual(result2InCI.message, undefined);
+
     // Make another local change
     tmpfs.writeFile('not-checked-in.txt', 'Pizza is not good at all!');
     const result3 = await resolveEnvironment({}, {});

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -438,6 +438,7 @@ async function resolveAfterSha(
     GITHUB_SHA,
     BUILD_SOURCEVERSION,
     SYSTEM_PULLREQUEST_SOURCEBRANCH,
+    CI,
   } = env;
 
   const sha = CIRCLE_SHA1 || TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT;
@@ -478,7 +479,11 @@ async function resolveAfterSha(
       return GITHUB_SHA;
     }
   }
-  return getHeadShaWithLocalChanges();
+  const headShaWithLocalChanges = getHeadShaWithLocalChanges();
+  if (CI) {
+    return headShaWithLocalChanges.headSha;
+  }
+  return headShaWithLocalChanges;
 }
 
 function resolveFallbackShas(


### PR DESCRIPTION
In case the CI environment has one or more changes in local files (possibly not part of the git index or the app itself) we shouldn't include those changes in the sha resolution. Locally we want that to ensure we get unique shas for unique changes but we need to treat CI as a pristine environment (even if it isn't).