### PR TITLE
Throw if apiKey or apiSecret are missing in config file

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -317,6 +317,9 @@ describe('main', () => {
         tmpfs.writeFile(
           'happo.config.ts',
           `export default {
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+
             integration: {
               type: 'storybook',
             },

--- a/src/config/__tests__/loadConfig.test.ts
+++ b/src/config/__tests__/loadConfig.test.ts
@@ -153,6 +153,36 @@ describe('findConfigFile', () => {
 });
 
 describe('loadConfigFile', () => {
+  it('throws an error if the apiKey is missing', async () => {
+    tmpfs.mock({
+      'happo.config.ts': `
+        export default {
+          apiSecret: 'test-api-secret',
+        };
+      `,
+    });
+
+    await assert.rejects(
+      loadConfigFile(findConfigFile()),
+      /Missing `apiKey` in your Happo config/,
+    );
+  });
+
+  it('throws an error if the apiSecret is missing', async () => {
+    tmpfs.mock({
+      'happo.config.ts': `
+        export default {
+          apiKey: 'test-api-key',
+        };
+      `,
+    });
+
+    await assert.rejects(
+      loadConfigFile(findConfigFile()),
+      /Missing `apiSecret` in your Happo config/,
+    );
+  });
+
   it('loads the config file', async () => {
     tmpfs.mock({
       'happo.config.ts': `
@@ -174,6 +204,8 @@ describe('loadConfigFile', () => {
     tmpfs.mock({
       'happo.config.ts': `
         export default {
+          apiKey: 'test-api-key',
+          apiSecret: 'test-api-secret',
         };
       `,
     });
@@ -200,6 +232,8 @@ describe('loadConfigFile', () => {
         export default {
           endpoint: 'https://test-endpoint.com',
           githubApiUrl: 'https://test-github-api-url.com',
+          apiKey: 'test-api-key',
+          apiSecret: 'test-api-secret',
 
           integration: {
             type: 'cypress',

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -29,6 +29,20 @@ export function findConfigFile(): string {
   return configFilePath;
 }
 
+function validateConfig(config: ConfigWithDefaults) {
+  if (!config.apiKey) {
+    throw new Error(
+      'Missing `apiKey` in your Happo config. Reference yours at https://happo.io/settings',
+    );
+  }
+
+  if (!config.apiSecret) {
+    throw new Error(
+      'Missing `apiSecret` in your Happo config. Reference yours at https://happo.io/settings',
+    );
+  }
+}
+
 export async function loadConfigFile(
   configFilePath: string,
 ): Promise<ConfigWithDefaults> {
@@ -69,10 +83,14 @@ export async function loadConfigFile(
     target.prefersReducedMotion = target.prefersReducedMotion ?? true;
   }
 
-  return {
+  const configWithDefaults = {
     endpoint: 'https://happo.io',
     githubApiUrl: 'https://api.github.com',
     targets: allTargets,
     ...config.default,
   };
+
+  validateConfig(configWithDefaults);
+
+  return configWithDefaults;
 }


### PR DESCRIPTION
There's probably more validation we could do here, but this is a good step in the right direction that should help people out if they happen to run into this issue. This will prevent them from running into more obscure errors later in the execution, such as "Zero-length key is not supported".