### PR TITLE
Improve package.json metadata for storybook integration catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "happo",
   "version": "6.0.1",
-  "description": "Visual regression testing and accessibility testing",
+  "description": "Catch unexpected visual and accessibility changes and UI bugs",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -145,16 +145,35 @@
     "mime-types": "^3.0.1",
     "srcset": "^5.0.2"
   },
+  "storybook": {
+    "displayName": "Happo",
+    "icon": "https://happo.io/static/happo-hippo.png",
+    "supportedFrameworks": [
+      "angular",
+      "ember",
+      "html",
+      "preact",
+      "react",
+      "react-native",
+      "svelte",
+      "vue",
+      "web-components"
+    ],
+    "unsupportedFrameworks": []
+  },
   "keywords": [
+    "storybook-addon",
     "accessibility",
     "cypress",
     "playwright",
     "regression",
     "storybook",
+    "test",
     "testing",
     "ui",
-    "visual regression",
-    "visual"
+    "visual-regression",
+    "visual",
+    "vrt"
   ],
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
Documentation on this can be found here:

  https://storybook.js.org/docs/addons/integration-catalog#addon-metadata

For supported frameworks, while we haven't tested this with everything in the list, I'm not aware of anything that would prevent it from working with any of these frameworks, so I decided to just use the entire list.

One requirement listed for addons, is this:

> preset.js file written as an ES5 module at the root level

While we have a preset.js file, it is not at the root level of the package. I am hoping that it will be okay though. We'll see!

Part of HAP-526