### PR TITLE
Set device scale factor to 2, allow for configuration

### DIFF
--- a/src/config/__tests__/loadConfig.test.ts
+++ b/src/config/__tests__/loadConfig.test.ts
@@ -222,6 +222,7 @@ describe('loadConfigFile', () => {
         viewport: '1024x768',
         freezeAnimations: 'last-frame',
         prefersReducedMotion: true,
+        deviceScaleFactor: 2,
       },
     });
   });
@@ -245,6 +246,7 @@ describe('loadConfigFile', () => {
               viewport: '800x600',
               freezeAnimations: 'first-frame',
               prefersReducedMotion: false,
+              deviceScaleFactor: 1,
             },
             safari: {
               type: 'safari',
@@ -273,18 +275,21 @@ describe('loadConfigFile', () => {
         viewport: '800x600',
         freezeAnimations: 'first-frame',
         prefersReducedMotion: false,
+        deviceScaleFactor: 1,
       },
       safari: {
         type: 'safari',
         viewport: '1024x768',
         freezeAnimations: 'last-frame',
         prefersReducedMotion: true,
+        deviceScaleFactor: 2,
       },
       firefox: {
         type: 'firefox',
         viewport: '800x600',
         freezeAnimations: 'first-frame',
         prefersReducedMotion: false,
+        deviceScaleFactor: 2,
       },
     });
   });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -305,6 +305,13 @@ interface DesktopTarget extends BaseTarget {
   viewport: `${number}x${number}`;
 
   /**
+   * Set the device scale factor for the browser
+   *
+   * This defaults to 2.
+   */
+  deviceScaleFactor?: 1 | 2;
+
+  /**
    * By default, Happo makes the browser prefer reduced motion when rendering
    * the UI. Set `prefersReducedMotion: false` to disable this behavior.
    */
@@ -324,6 +331,7 @@ export interface TargetWithDefaults extends BaseTarget {
   viewport: `${number}x${number}`;
   __dynamic: boolean;
   prefersReducedMotion?: boolean;
+  deviceScaleFactor?: 1 | 2;
 }
 
 export interface ConfigWithDefaults extends Config {

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -81,6 +81,7 @@ export async function loadConfigFile(
     target.viewport = target.viewport || '1024x768';
     target.freezeAnimations = target.freezeAnimations || 'last-frame';
     target.prefersReducedMotion = target.prefersReducedMotion ?? true;
+    target.deviceScaleFactor = target.deviceScaleFactor ?? 2;
   }
 
   const configWithDefaults = {


### PR DESCRIPTION


I have been investigating some flake caused by images with border-radius and background colors. I determined that it can be resolved by setting the device scale factor to 2.

While we could set the device scale factor to 2 on our workers, I think that will end up being somewhat disruptive. So, to help make it easier for people to adopt this change we can handle it at the configuration level. This will make it so the device scale factor bump comes in with a pull request, which will avoid having a bunch of confusing diffs for everyone--since either you will have a merge base before the PR or after the PR, so the comparisons will consistently use the same device scale factor.

In order for this to actually work, we will need to deploy a new worker that is able to consume this value correctly.
