### PR TITLE
Remove waitForSomeContent

### DIFF
--- a/src/storybook/browser/register.ts
+++ b/src/storybook/browser/register.ts
@@ -38,7 +38,6 @@ const time = globalThis.happoTime || {
   originalSetTimeout: globalThis.setTimeout.bind(globalThis),
 };
 
-const ASYNC_TIMEOUT = 100;
 const STORY_STORE_TIMEOUT = 10_000;
 
 type HookFunction = ({
@@ -80,22 +79,6 @@ class ForcedHappoScreenshot extends Error {
     this.type = 'ForcedHappoScreenshot';
     this.step = stepLabel;
   }
-}
-
-async function waitForSomeContent(
-  elem: HTMLElement,
-  start = time.originalDateNow(),
-): Promise<string> {
-  const html = elem.innerHTML.trim();
-  const duration = time.originalDateNow() - start;
-
-  if (html === '' && duration < ASYNC_TIMEOUT) {
-    return new Promise((resolve) =>
-      time.originalSetTimeout(() => resolve(waitForSomeContent(elem, start)), 10),
-    );
-  }
-
-  return html;
 }
 
 async function waitForWaitFor(
@@ -443,13 +426,10 @@ globalThis.happo.nextExample = async (): Promise<NextExampleResult | undefined> 
       await themeSwitcher(theme, channel);
     }
 
-    await waitForSomeContent(rootElement);
-
     if (/sb-show-errordisplay/.test(document.body.className)) {
       // It's possible that the error is from unmounting the previous story. We
       // can try re-rendering in this case.
       channel.emit('forceReRender');
-      await waitForSomeContent(rootElement);
     }
 
     if (beforeScreenshot && typeof beforeScreenshot === 'function') {


### PR DESCRIPTION
This function was added in
https://github.com/happo/happo-plugin-storybook/commit/28c9e16 at a time when we weren't using Storybook events to know when a story was ready and rendered. We basically told Storybook to render and then waited up to 100ms for some markup to show up in the root element.

I'm removing this as part of investigating a strange pattern I'm seeing in the Happo Storybook test suite for happo.io where all stories take just over 100ms to render. The closest candidate to adding a 100ms delay is the waitForSomeContent function, and I feel confident it is not useful at all since we added the event listener.