### PR TITLE
Use temporary pull-request token for PRs from forks

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -204,10 +204,11 @@ export async function main(
       return;
     }
 
+    const environment = await resolveEnvironment(args.values);
+
     // Get config file path (use --config if provided, otherwise find default)
     const configFilePath = makeAbsolute(args.values.config || findConfigFile());
-    const config = await loadConfigFile(configFilePath);
-    const environment = await resolveEnvironment(args.values);
+    const config = await loadConfigFile(configFilePath, environment, logger);
 
     // Handle positional arguments (commands)
     const command = args.positionals[0];

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -262,6 +262,8 @@ export default async function runWithWrapper(
           ...process.env,
           HAPPO_E2E_PORT: e2eServer.port.toString(),
           HAPPO_CONFIG_FILE: configFilePath,
+          HAPPO_API_KEY: happoConfig.apiKey,
+          HAPPO_API_SECRET: happoConfig.apiSecret,
         },
         shell: process.platform == 'win32',
       });


### PR DESCRIPTION
This was originally handled by the happo.io package here:

https://github.com/happo/happo.io/blob/932ce1b45a/src/loadUserConfig.js#L64-L90

We accidentally missed it when we ported the code over to this new repo. From the original commit message:

> Providing secret environment variables in CI to forks is tricky. Most
> CI environments, such as Travis, explicitly disable secrets when it
> detects that a run is triggered on a fork of a repo.
>
> https://github.com/travis-ci/travis-ci/issues/1946
>
> To work around this, I've adopted a separate auth mechanism for
> happo.io for outside pull requests. Instead of requiring an apiKey and
> an apiSecret, we use temporary tokens, pulled from the Happo API if we
> detect that we're in a fork (keys are missing). These tokens are much
> more limited in scope compared to the regular API tokens. We're
> basically allowing them to generate reports for the PR in question,
> and only for a limited time.

The tricky thing to get right now is making sure that these values are propagated correctly to the e2e controller. I decided to set some environment variables to make that happen.

Fixes HAP-543