### PR TITLE
Move CLI script to own file

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/happo/happo/issues",
   "homepage": "https://happo.io",
   "bin": {
-    "happo": "dist/cli/index.js"
+    "happo": "dist/cli/main.js"
   },
   "type": "module",
   "main": "./dist/config/index.js",
@@ -68,12 +68,12 @@
     "prepublishOnly": "pnpm clean && pnpm build",
     "storybook:dev": "storybook dev --config-dir src/storybook/__tests__/storybook-app -p ${PORT:-6007}",
     "test": "node --env-file-if-exists=.env.local ./scripts/test.ts",
-    "test:custom": "pnpm build:dist && pnpm build:custom && node --env-file-if-exists=.env.local dist/cli/index.js -c ./happoconfigs/happo.custom.config.ts",
-    "test:cypress": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/index.js -c ./happoconfigs/happo.cypress.config.ts e2e -- cypress run -C src/cypress/__cypress__/cypress.config.ts",
+    "test:custom": "pnpm build:dist && pnpm build:custom && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.custom.config.ts",
+    "test:cypress": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.cypress.config.ts e2e -- cypress run -C src/cypress/__cypress__/cypress.config.ts",
     "test:cypress:open": "cypress open -C src/cypress/__cypress__/cypress.config.ts",
-    "test:playwright": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/index.js -c ./happoconfigs/happo.playwright.config.ts e2e -- playwright test",
-    "test:storybook": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/index.js -c ./happoconfigs/happo.storybook.config.ts",
-    "test:pages": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/index.js -c ./happoconfigs/happo.pages.config.ts",
+    "test:playwright": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright.config.ts e2e -- playwright test",
+    "test:storybook": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts",
+    "test:pages": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.pages.config.ts",
     "tsc": "tsc --build tsconfig.json"
   },
   "browserslist": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -24,7 +24,7 @@ const DIST_CONFIGS: Array<EntryConfig> = [
   },
 
   {
-    entryPoints: ['src/cli/index.ts'],
+    entryPoints: ['src/cli/main.ts'],
     outdir: 'dist/cli',
     platform: 'node',
   },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -356,7 +356,3 @@ async function handleE2ECommand(
   );
   process.exitCode = exitCode;
 }
-
-if (import.meta.main) {
-  await main();
-}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,3 @@
+import { main } from './index.ts';
+
+await main();


### PR DESCRIPTION
We're seeing people running into issues with the `happo` command silently exiting directly. This is because `import.meta.main` resolves to a falsy value, so the main function is never executed.

The check for import.meta.main was added in 9a78605e43c5f93 to make it easier to test cli/index.ts, conditionally only executing the main function if it was run as a CLI command. We can keep tests happy by simply moving the CLI entrypoint out of the way.