### PR TITLE
Fix storybook data fetch story test

### DIFF
--- a/src/storybook/__tests__/storybook-app/Story.stories.ts
+++ b/src/storybook/__tests__/storybook-app/Story.stories.ts
@@ -48,14 +48,15 @@ function DataFetchComponent(): ReactNode {
   const [xhr, setXhr] = useState(false);
   const [fetch, setFetch] = useState(false);
   useEffect(() => {
+    const apiUrl = 'https://api.restful-api.dev/objects';
     const xhr = new XMLHttpRequest();
     xhr.addEventListener('load', async () => {
       setXhr(true);
-      await globalThis.fetch('https://reqres.in/api/users?page=2');
-      await globalThis.fetch('https://reqres.in/api/users?page=3');
+      await globalThis.fetch(`${apiUrl}/2`);
+      await globalThis.fetch(`${apiUrl}/3`);
       setFetch(true);
     });
-    xhr.open('GET', 'https://reqres.in/api/users?page=1', true);
+    xhr.open('GET', `${apiUrl}/1`, true);
     xhr.send();
   }, []);
   if (!xhr || !fetch) {


### PR DESCRIPTION
We were making requests against an external domain that started responding with 403 forbidden. To fix this, I wanted to spin up little sever along with storybook to serve some API calls via a vite plugin. That seemed to work when running Storybook locally, but it did not resolve the issue when running in Happo. So, instead I decided to use a different URL for these requests.