### PR TITLE
Handle HTTP 204 No Content in makeHappoApiRequest

### DIFF
--- a/src/network/__tests__/makeHappoAPIRequest.test.ts
+++ b/src/network/__tests__/makeHappoAPIRequest.test.ts
@@ -66,6 +66,9 @@ before(async () => {
           result: 'Hello world!',
         }),
       );
+    } else if (req.url === '/no-content') {
+      res.writeHead(204);
+      res.end();
     } else if (
       req.url === '/form-data' ||
       (req.url === '/form-data-failure-retry' && errorTries > 2)
@@ -229,6 +232,12 @@ it('can retry uploading form data with buffers', async () => {
       ],
     },
   });
+});
+
+it('returns null for 204 No Content responses', async () => {
+  props.url = 'http://localhost:8990/no-content';
+  const response = await makeHappoAPIRequest(props, config, options, logger);
+  assert.strictEqual(response, null);
 });
 
 describe('when the request fails twice and then succeeds', () => {

--- a/src/network/makeHappoAPIRequest.ts
+++ b/src/network/makeHappoAPIRequest.ts
@@ -104,6 +104,10 @@ export default async function makeHappoAPIRequest(
     logger,
   );
 
+  if (response.status === 204) {
+    return null;
+  }
+
   // We expect API responses to be JSON, so let's parse it as JSON here for
   // convenience.
   const result = await response.json();


### PR DESCRIPTION
When there is no content, calling `response.json()` results throws an error "Unecpected end of JSON input". We can avoid this by returning null when we receive a 204 status code. The cancel API endpoint behaves this way, so this should make the ride there a little smoother.