### PR TITLE
Mark modal dialogs with data-happo-modal

### DIFF
--- a/src/browser/__playwright__/takeDOMSnapshot.spec.ts
+++ b/src/browser/__playwright__/takeDOMSnapshot.spec.ts
@@ -65,6 +65,53 @@ test('regular elements', async ({ page }) => {
   expect(snapshot.cssBlocks).toEqual([]);
 });
 
+test('modal dialogs are marked with data-happo-modal', async ({ page }) => {
+  await setupPage(page);
+
+  await page.goto('/regular-elements');
+  await page.evaluate(() => {
+    const dialog = document.querySelector('dialog');
+    if (!dialog) {
+      throw new Error('Element not found');
+    }
+    dialog.showModal();
+  });
+
+  const snapshot = await page.evaluate(() => {
+    return globalThis.happo.takeDOMSnapshot({
+      doc: document,
+      element: document.body,
+    });
+  });
+
+  expect(snapshot.html).toMatch(
+    /<dialog open="" data-happo-focus="true" data-happo-modal="true">/s,
+  );
+});
+
+test('non-modal dialogs are not marked with data-happo-modal', async ({ page }) => {
+  await setupPage(page);
+
+  await page.goto('/regular-elements');
+  await page.evaluate(() => {
+    const dialog = document.querySelector('dialog');
+    if (!dialog) {
+      throw new Error('Element not found');
+    }
+    dialog.show();
+  });
+
+  const snapshot = await page.evaluate(() => {
+    return globalThis.happo.takeDOMSnapshot({
+      doc: document,
+      element: document.body,
+    });
+  });
+
+  expect(snapshot.html).toMatch(/<dialog open="" data-happo-focus="true">/s);
+  expect(snapshot.html).not.toMatch(/data-happo-modal="true"/s);
+});
+
 test('style collection', async ({ page }) => {
   await setupPage(page);
 

--- a/src/browser/__playwright__/test-assets/regular-elements/index.html
+++ b/src/browser/__playwright__/test-assets/regular-elements/index.html
@@ -7,5 +7,6 @@
         ><img src="/regular-elements/happo-logo.png" alt="happo-logo"
       /></a>
     </main>
+    <dialog>Good dialog</dialog>
   </body>
 </html>

--- a/src/browser/takeDOMSnapshot.ts
+++ b/src/browser/takeDOMSnapshot.ts
@@ -377,6 +377,25 @@ function inlineShadowRoots(element: Element): void {
   }
 }
 
+/**
+ * Adds data-happo-modal to the first modal dialog that is open, and removes it
+ * from all other dialogs.
+ */
+function markModalDialogs(element: Element): void {
+  const cleanups = element.querySelectorAll<HTMLDialogElement>(
+    'dialog[data-happo-modal]',
+  );
+  for (const cleanup of cleanups) {
+    delete cleanup.dataset.happoModal;
+  }
+
+  const openModal = element.querySelector<HTMLDialogElement>('dialog:modal[open]');
+  if (!openModal) {
+    return;
+  }
+  openModal.dataset.happoModal = 'true';
+}
+
 function findSvgElementsWithSymbols(element: Element): Array<SVGElement> {
   return [...element.ownerDocument.querySelectorAll('svg')].filter((svg) =>
     svg.querySelector('symbol'),
@@ -443,6 +462,7 @@ export default function takeDOMSnapshot({
     }
 
     inlineShadowRoots(element);
+    markModalDialogs(element);
 
     assetUrls.push(
       ...getElementAssetUrls(


### PR DESCRIPTION
We noticed a problem where modal-specific styles that are applied to modal dialogs (i.e. `:modal`), which are only applied when the dialog is shown via JS `.showModal()` were not showing up in Happo screenshots.

To make this work, we need the worker to be able to identify which dialogs were shown via `.showModal()` and which were not. We can achieve that by adding a data attribute to these dialogs.

This will require a change on the worker before it will fully work.