### PR TITLE
Move node shebang from index.ts to main.ts

### DIFF
--- a/src/cli/__tests__/main.test.ts
+++ b/src/cli/__tests__/main.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+import { execSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+
+describe('main', () => {
+  it('is directly executable from the command line', () => {
+    let message: string = '';
+
+    try {
+      execSync('./src/cli/main.ts', { stdio: 'pipe' });
+    } catch (error) {
+      message = String(error);
+    }
+
+    assert.match(message, /Happo config file could not be found/);
+    assert.doesNotMatch(message, /command not found/);
+    assert.doesNotMatch(message, /syntax error/);
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import path from 'node:path';
 import { parseArgs } from 'node:util';
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { main } from './index.ts';
 
 await main();


### PR DESCRIPTION
CLI `dist/cli/main.js` file is missing `#!/usr/bin/env node` at the very top. This causes `pnpm happo` to fail on systems where `pnpm install` prefers symlinking instead of creating command shims, e.g. macOS.

Steps to repro —

1. `pnpm install happo@6.2.0`
2. `pnpm happo`

```
/node_modules/.bin/happo: line 1: import: command not found
/node_modules/.bin/happo: line 2: startServer: command not found
/node_modules/.bin/happo: line 3: syntax error near unexpected token `}'
/node_modules/.bin/happo: line 3: `} from "./chunk-JTRP4JVC.js";'
```

Cross-platform workarounds:

1. Directly-running script: `node node_modules/happo/dist/cli/main.js`
2. Forcing PNPM to create command shims:

```
// pnpm-workspace.yaml
preferSymlinkedExecutables: false
```

Seems to have originated in https://github.com/happo/happo/pull/311

I am fixing this by moving the shebang over to the main.ts file and change the permissions on the file to make it directly executable.

I decided to add a bit of a test that should prove that this file can be executed, but since it runs against the pre-built source instead of the built file it isn't a full and complete test. I think that's okay though.

It is unclear to me if the execute permission is necessary for this or not, but it is necessary for the way I wrote the test, I don't see harm in it, and I like that it signals intent.

Fixes #339 (FYI @sslogar-plaid)