### PR TITLE
Add deepCompare configuration support

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -108,6 +108,50 @@ interface PagesIntegration {
   pages: Array<Page>;
 }
 
+/**
+ * Settings for deep compare functionality
+ */
+export interface DeepCompareSettings {
+  /**
+   * Threshold for comparing images with the given diff algorithm (float between
+   * 0 and 1). 1 means all differences are allowed. 0 means no differences are
+   * allowed. A good starting value is 0.03 for color-delta and 0.01 for ssim.
+   */
+  compareThreshold: number;
+
+  /**
+   * Algorithm to use for diff comparison. Must be "color-delta" or "ssim".
+   * Defaults to "color-delta" if not provided. Note that "ssim" is experimental
+   * and may be removed in the future.
+   */
+  diffAlgorithm?: 'color-delta' | 'ssim';
+
+  /**
+   * Threshold for ignoring individual pixel differences, side-stepping the
+   * compare threshold. Used relatively to the image size. E.g. a value of 0.01
+   * means 1% of the pixels can be above the compare threshold. Use this option
+   * if your screenshots contain images or graphics with sharp noise. It is not
+   * recommended to use this option for other types of diffs. (float
+   * between 0 and 1).
+   */
+  ignoreThreshold?: number;
+
+  /**
+   * Whether to ignore whitespace in the diff. If true, whitespace differences
+   * will not be considered when comparing images. Whitespace is defined as a
+   * vertical section in a screenshot containing a single solid color.
+   */
+  ignoreWhitespace?: boolean;
+
+  /**
+   * Whether to apply blur to the diff. This can be used to smooth out subtle
+   * differences that would otherwise be above the compare threshold. This
+   * should mainly be used when your screenshots have a high contrast and you
+   * want to smooth out some of the sharpness that can otherwise cause flakiness.
+   */
+  applyBlur?: boolean;
+}
+
 export interface Config {
   /**
    * Key used to authenticate with the Happo API. Never store this in plain
@@ -163,6 +207,11 @@ export interface Config {
     | PlaywrightIntegration
     | CustomIntegration
     | PagesIntegration;
+
+  /**
+   * An object with settings for deep compare.
+   */
+  deepCompare?: DeepCompareSettings;
 }
 
 type MobileSafariBrowserType = 'ios-safari' | 'ipad-safari';

--- a/src/network/__tests__/createAsyncComparison.test.ts
+++ b/src/network/__tests__/createAsyncComparison.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert';
+import type { Mock } from 'node:test';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import type { ConfigWithDefaults, DeepCompareSettings } from '../../config/index.ts';
+import type { EnvironmentResult } from '../../environment/index.ts';
+import type makeHappoAPIRequest from '../makeHappoAPIRequest.ts';
+
+interface TestLogger {
+  log: Mock<Console['log']>;
+  error: Mock<Console['error']>;
+}
+
+let logger: TestLogger;
+let config: ConfigWithDefaults;
+let environment: EnvironmentResult;
+let createAsyncComparison: typeof import('../createAsyncComparison.ts').default;
+
+const makeHappoAPIRequestMock: Mock<typeof makeHappoAPIRequest> = mock.fn(
+  async () => {
+    return {
+      id: 123,
+      statusImageUrl: 'https://happo.io/api/reports/123/status-image',
+      compareUrl: 'https://happo.io/api/reports/123/compare',
+    };
+  },
+);
+
+// mock makeHappoAPIRequest.ts *before* importing createAsyncComparison
+mock.module('../makeHappoAPIRequest.ts', {
+  defaultExport: makeHappoAPIRequestMock,
+});
+
+beforeEach(async () => {
+  logger = {
+    log: mock.fn(),
+    error: mock.fn(),
+  };
+
+  // Now import the SUT; it will see the mocked module
+  ({ default: createAsyncComparison } = await import('../createAsyncComparison.ts'));
+
+  config = {
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+    endpoint: 'https://happo.io',
+    githubApiUrl: 'https://api.github.com',
+    targets: {
+      chrome: {
+        type: 'chrome',
+        viewport: '1024x768',
+        __dynamic: false,
+      },
+    },
+    integration: {
+      type: 'storybook',
+    },
+  };
+
+  environment = {
+    beforeSha: 'before-sha',
+    afterSha: 'after-sha',
+    link: 'https://github.com/owner/repo/pull/123',
+    message: 'Test message',
+    authorEmail: 'test@example.com',
+    notify: undefined,
+    fallbackShas: undefined,
+    ci: false,
+    nonce: undefined,
+    githubToken: undefined,
+    debugMode: false,
+  };
+
+  makeHappoAPIRequestMock.mock.resetCalls();
+});
+
+afterEach(() => {
+  makeHappoAPIRequestMock.mock.resetCalls();
+});
+
+describe('createAsyncComparison', () => {
+  it('passes deepCompare settings when configured', async () => {
+    const deepCompare: DeepCompareSettings = {
+      compareThreshold: 0.5,
+      diffAlgorithm: 'color-delta',
+      ignoreThreshold: 0.01,
+      ignoreWhitespace: true,
+      applyBlur: false,
+    };
+
+    config.deepCompare = deepCompare;
+
+    await createAsyncComparison(config, environment, logger);
+
+    assert.strictEqual(makeHappoAPIRequestMock.mock.callCount(), 1);
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+    assert.strictEqual(
+      call.arguments[0]?.path,
+      '/api/reports/before-sha/compare/after-sha',
+    );
+    assert.strictEqual(call.arguments[0]?.method, 'POST');
+
+    const body = call.arguments[0]?.body as {
+      deepCompare?: DeepCompareSettings;
+      link?: string;
+      message?: string;
+      author?: string;
+      project?: string;
+      isAsync?: boolean;
+    };
+
+    assert.ok(body);
+    assert.deepStrictEqual(body.deepCompare, deepCompare);
+    assert.strictEqual(body.link, environment.link);
+    assert.strictEqual(body.message, environment.message);
+    assert.strictEqual(body.author, environment.authorEmail);
+    assert.strictEqual(body.isAsync, true);
+  });
+
+  it('does not pass deepCompare when not configured', async () => {
+    // Ensure deepCompare is undefined
+    delete config.deepCompare;
+
+    await createAsyncComparison(config, environment, logger);
+
+    assert.strictEqual(makeHappoAPIRequestMock.mock.callCount(), 1);
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+
+    const body = call.arguments[0]?.body as {
+      deepCompare?: DeepCompareSettings;
+      [key: string]: unknown;
+    };
+
+    assert.ok(body);
+    assert.strictEqual('deepCompare' in body, false);
+  });
+
+  it('passes deepCompare settings', async () => {
+    const deepCompare: DeepCompareSettings = {
+      compareThreshold: 0.8,
+      diffAlgorithm: 'ssim',
+    };
+
+    config.deepCompare = deepCompare;
+
+    await createAsyncComparison(config, environment, logger);
+
+    assert.strictEqual(makeHappoAPIRequestMock.mock.callCount(), 1);
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+
+    const body = call.arguments[0]?.body as {
+      deepCompare?: DeepCompareSettings;
+    };
+
+    assert.ok(body);
+    assert.ok(body.deepCompare);
+    assert.strictEqual(body.deepCompare.compareThreshold, 0.8);
+    assert.strictEqual(body.deepCompare.diffAlgorithm, 'ssim');
+  });
+
+  it('throws error when beforeSha equals afterSha', async () => {
+    environment.beforeSha = 'same-sha';
+    environment.afterSha = 'same-sha';
+
+    await assert.rejects(
+      () => createAsyncComparison(config, environment, logger),
+      /Cannot create an async comparison between the same SHA/,
+    );
+  });
+});

--- a/src/network/createAsyncComparison.ts
+++ b/src/network/createAsyncComparison.ts
@@ -1,4 +1,4 @@
-import type { ConfigWithDefaults } from '../config/index.ts';
+import type { ConfigWithDefaults, DeepCompareSettings } from '../config/index.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
 import type { Logger } from '../isomorphic/types.ts';
 import makeHappoAPIRequest from './makeHappoAPIRequest.ts';
@@ -53,19 +53,34 @@ export default async function createAsyncComparison(
     );
   }
 
+  const body: {
+    link: string | undefined;
+    message: string | undefined;
+    author: string | undefined;
+    project: string | undefined;
+    isAsync: boolean;
+    notify: string | undefined;
+    fallbackShas: Array<string> | undefined;
+    deepCompare?: DeepCompareSettings;
+  } = {
+    link,
+    message,
+    author: authorEmail,
+    project: config.project,
+    isAsync: true,
+    notify,
+    fallbackShas,
+  };
+
+  if (config.deepCompare) {
+    body.deepCompare = config.deepCompare;
+  }
+
   const result = await makeHappoAPIRequest(
     {
       path: `/api/reports/${beforeSha}/compare/${afterSha}`,
       method: 'POST',
-      body: {
-        link,
-        message,
-        author: authorEmail,
-        project: config.project,
-        isAsync: true,
-        notify,
-        fallbackShas,
-      },
+      body,
     },
     config,
     { retryCount: 3 },


### PR DESCRIPTION
Add support for configuring deep compare settings in the Happo config file. The deepCompare option allows users to customize image comparison behavior with the following settings:

- compareThreshold (required): Threshold for comparing images (0-1)
- diffAlgorithm (optional): Algorithm to use ("color-delta" or "ssim", defaults to "color-delta")
- ignoreThreshold (optional): Threshold for ignoring pixel differences (0-1)
- ignoreWhitespace (optional): Whether to ignore whitespace in diffs
- applyBlur (optional): Whether to apply blur to smooth differences

The deepCompare object is only sent in compare requests when configured, allowing remote defaults to apply when not specified.

This change depends on a change to the Happo API (currently in progress).