### PR TITLE
Make assertElement work across realms

### DIFF
--- a/src/browser/__tests__/assertElement.test.ts
+++ b/src/browser/__tests__/assertElement.test.ts
@@ -15,42 +15,42 @@ describe('assertElement', () => {
     initDOM('<!DOCTYPE html>');
     const { document: doc } = globalThis.window;
     const el = doc.createTextNode('text node');
-    assert.throws(() => assertElement(el, globalThis.window));
+    assert.throws(() => assertElement(el));
   });
 
   it('does not throw if the element is an HTMLElement', () => {
     initDOM('<!DOCTYPE html>');
     const { document: doc } = globalThis.window;
     const el = doc.createElement('div');
-    assert.doesNotThrow(() => assertElement(el, globalThis.window));
+    assert.doesNotThrow(() => assertElement(el));
   });
 
   it('does not throw if the element is an MathMLElement', () => {
     initDOM('<!DOCTYPE html>');
     const { document: doc } = globalThis.window;
     const el = doc.createElement('math');
-    assert.doesNotThrow(() => assertElement(el, globalThis.window));
+    assert.doesNotThrow(() => assertElement(el));
   });
 
   it('does not throw if the element is an SVGElement', () => {
     initDOM('<!DOCTYPE html>');
     const { document: doc } = globalThis.window;
     const el = doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    assert.doesNotThrow(() => assertElement(el, globalThis.window));
+    assert.doesNotThrow(() => assertElement(el));
   });
 
   it('does not throw if the element is an array of elements', () => {
     initDOM('<!DOCTYPE html>');
     const { document: doc } = globalThis.window;
     const el = doc.createElement('div');
-    assert.doesNotThrow(() => assertElement([el], globalThis.window));
+    assert.doesNotThrow(() => assertElement([el]));
   });
 
   it('throws if the element is an array of non-elements', () => {
     initDOM('<!DOCTYPE html>');
     const { document: doc } = globalThis.window;
     const el = doc.createElement('div');
-    assert.throws(() => assertElement([el, 'not an element'], globalThis.window));
+    assert.throws(() => assertElement([el, 'not an element']));
   });
 
   it('does not throw if the element is a NodeList of elements', () => {
@@ -59,6 +59,51 @@ describe('assertElement', () => {
     const el = doc.createElement('div');
     doc.body.append(el);
     const nodeList = doc.querySelectorAll('div');
-    assert.doesNotThrow(() => assertElement(nodeList, globalThis.window));
+    assert.doesNotThrow(() => assertElement(nodeList));
+  });
+
+  it('does not throw if the element is in an iframe', () => {
+    initDOM('<!DOCTYPE html>');
+    const { document: doc } = globalThis.window;
+    const iframe = doc.createElement('iframe');
+    doc.body.append(iframe);
+    assert.doesNotThrow(() => assertElement(iframe.contentDocument?.body));
+  });
+
+  it('does not throw if the element is a NodeList of elements in an iframe', () => {
+    initDOM('<!DOCTYPE html>');
+    const { document: doc } = globalThis.window;
+    const iframe = doc.createElement('iframe');
+    doc.body.append(iframe);
+
+    const els = [
+      iframe.contentDocument?.createElement('div'),
+      iframe.contentDocument?.createElement('div'),
+    ];
+
+    for (const el of els) {
+      if (!el) {
+        throw new Error('Failed to create element');
+      }
+
+      iframe.contentDocument?.body.append(el);
+    }
+
+    const nodeList = iframe.contentDocument?.body.querySelectorAll('div');
+    assert.doesNotThrow(() => assertElement(nodeList));
+  });
+
+  it('throws if the element is a NodeList of non-elements in an iframe', () => {
+    initDOM('<!DOCTYPE html>');
+    const { document: doc } = globalThis.window;
+    const iframe = doc.createElement('iframe');
+    doc.body.append(iframe);
+    const textNode = iframe.contentDocument?.createTextNode('text node');
+    if (!textNode || !iframe.contentDocument?.body) {
+      throw new Error('Failed to create text node in iframe');
+    }
+    iframe.contentDocument.body.append(textNode);
+    const nodeList = iframe.contentDocument.body.childNodes;
+    assert.throws(() => assertElement(nodeList));
   });
 });

--- a/src/browser/assertElement.ts
+++ b/src/browser/assertElement.ts
@@ -1,10 +1,43 @@
+function isIterableCollection(
+  element: NonNullable<unknown>,
+): element is Iterable<unknown> {
+  if (typeof element !== 'object') {
+    return false;
+  }
+
+  if (!('length' in element)) {
+    return false;
+  }
+
+  if (typeof element.length !== 'number') {
+    return false;
+  }
+
+  if (!('item' in element)) {
+    return false;
+  }
+
+  if (typeof element.item !== 'function') {
+    return false;
+  }
+
+  if (!(Symbol.iterator in element)) {
+    return false;
+  }
+
+  if (typeof element[Symbol.iterator] !== 'function') {
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Throws if the element is not a valid Element instance, an array of elements,
  * or a NodeList of elements.
  */
 export default function assertElement(
   element: unknown,
-  gt: typeof globalThis = globalThis.window,
 ): asserts element is Element | Array<Element> | NodeListOf<Element> {
   if (element == null) {
     throw new Error('element cannot be null or undefined');
@@ -14,18 +47,19 @@ export default function assertElement(
     throw new TypeError('element must be an object');
   }
 
-  if (Array.isArray(element) || element instanceof gt.NodeList) {
+  if (Array.isArray(element) || isIterableCollection(element)) {
     for (const el of element) {
-      assertElement(el, gt);
+      assertElement(el);
     }
+
     return;
   }
 
-  if ('nodeType' in element && element.nodeType !== gt.Node.ELEMENT_NODE) {
-    throw new Error('element must have a nodeType of ELEMENT_NODE');
+  if (!('nodeType' in element)) {
+    throw new TypeError('element must have a nodeType property');
   }
 
-  if (!(element instanceof gt.Element)) {
-    throw new TypeError('element must be an Element instance');
+  if (element.nodeType !== 1 /* ELEMENT_NODE */) {
+    throw new Error('element must have a nodeType of ELEMENT_NODE');
   }
 }

--- a/src/browser/takeDOMSnapshot.ts
+++ b/src/browser/takeDOMSnapshot.ts
@@ -417,7 +417,7 @@ export default function takeDOMSnapshot({
     throw new Error('doc.defaultView cannot be null or undefined');
   }
 
-  assertElement(oneOrMoreElements, doc.defaultView);
+  assertElement(oneOrMoreElements);
 
   const allElements = transformToElementArray(oneOrMoreElements);
   const htmlParts: Array<string> = [];


### PR DESCRIPTION
The assertElement function can fail incorrectly in Cypress, due to Cypress's use of different window and document objects. More details here:

https://glebbahmutov.com/cypress-examples/recipes/instanceof.html

This means that instanceof checks should probably be avoided in Cypress.

We can still preserve type safety by being just a little more careful with how we go about things here.

Since we are already checking the nodeType, which is just a constant 1, we don't really need the instanceof check at all for Element.

We can do something similar for our NodeList check, but since all we really care about is whether we can iterate over it, we can do a slightly different check for that behavior specifically.

I was unable to come up with a good test that would fail the instanceof NodeList check, but I think that should be okay.

Fixes #358