### PR TITLE
Fix using `includeAllElements` in Cypress

### DIFF
--- a/src/browser/__tests__/takeDOMSnapshot.test.ts
+++ b/src/browser/__tests__/takeDOMSnapshot.test.ts
@@ -79,11 +79,11 @@ describe('takeDOMSnapshot', () => {
 </html>
   `);
     const { document: doc } = globalThis.window;
-    const element = doc.querySelectorAll('button');
-    if (!element) {
-      throw new Error('Element not found');
+    const elements = doc.querySelectorAll('button');
+    if (!elements || elements.length === 0) {
+      throw new Error('Elements not found');
     }
-    const snapshot = takeDOMSnapshot({ doc, element });
+    const snapshot = takeDOMSnapshot({ doc, element: elements });
     assert.equal(
       snapshot.html.trim(),
       `

--- a/src/cypress/__cypress__/fixtures/index.html
+++ b/src/cypress/__cypress__/fixtures/index.html
@@ -4,6 +4,8 @@
     <main>
       <h1>Hello world</h1>
       <p>This is a test</p>
+      <button>Hello</button>
+      <button>World</button>
     </main>
   </body>
 </html>

--- a/src/cypress/__cypress__/tests/happo.spec.ts
+++ b/src/cypress/__cypress__/tests/happo.spec.ts
@@ -6,6 +6,17 @@ describe('happo spec', () => {
       variant: 'default',
     });
 
+    cy.get('button').happoScreenshot({
+      component: 'button',
+      variant: 'single element',
+    });
+
+    cy.get('button').happoScreenshot({
+      component: 'button',
+      variant: 'multiple elements',
+      includeAllElements: true,
+    });
+
     cy.get('p').happoScreenshot();
   });
 });

--- a/src/cypress/index.ts
+++ b/src/cypress/index.ts
@@ -92,7 +92,9 @@ Cypress.Commands.add(
         ? responsiveInlinedCanvases
         : config.responsiveInlinedCanvases;
 
-    const element = includeAllElements ? originalSubject : originalSubject[0];
+    const element = includeAllElements
+      ? Array.from(originalSubject)
+      : originalSubject[0];
     if (!element) {
       throw new Error('element cannot be null or undefined');
     }


### PR DESCRIPTION
The `includeAllElements` option is meant to support the case of including multiple elements matching the selector (instead of just the first one). When using this with Cypress however, the test suite would fail with a `element must have a nodeType property` error.

To address this, we can convert the collection to an array before passing it along.

Fixes #358 