### PR TITLE
Improve job handling for e2e runs

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -590,7 +590,16 @@ describe('main', () => {
             logger,
           );
           assert.notStrictEqual(process.exitCode, 0);
-          assert(makeHappoAPIRequestMock.mock.callCount() === 0);
+          assert(makeHappoAPIRequestMock.mock.callCount() === 1);
+          const startJobRequest = makeHappoAPIRequestMock.mock.calls.at(-1);
+          if (!startJobRequest) {
+            throw new Error('No start job request found');
+          }
+          assert.strictEqual(
+            startJobRequest.arguments[1]?.endpoint,
+            'https://happo.io',
+          );
+          assert.ok(startJobRequest.arguments[0]?.path?.includes('/api/jobs'));
         });
       });
     });

--- a/src/network/__tests__/cancelJob.test.ts
+++ b/src/network/__tests__/cancelJob.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert';
+import type { Mock } from 'node:test';
+import { beforeEach, describe, it, mock } from 'node:test';
+
+import type { ConfigWithDefaults } from '../../config/index.ts';
+import type { EnvironmentResult } from '../../environment/index.ts';
+import { ErrorWithStatusCode } from '../fetchWithRetry.ts';
+
+interface Logger {
+  log: Mock<Console['log']>;
+  error: Mock<Console['error']>;
+}
+
+type MakeHappoAPIRequestImpl = (...args: Array<unknown>) => Promise<unknown>;
+
+let makeHappoAPIRequestImpl: MakeHappoAPIRequestImpl;
+const makeHappoAPIRequestMock = mock.fn(async (...args: Array<unknown>) => {
+  return await makeHappoAPIRequestImpl(...args);
+});
+
+mock.module('../makeHappoAPIRequest.ts', {
+  defaultExport: makeHappoAPIRequestMock,
+});
+
+let cancelJob: typeof import('../cancelJob.ts').default;
+let logger: Logger;
+let config: ConfigWithDefaults;
+let environment: EnvironmentResult;
+
+beforeEach(async () => {
+  logger = {
+    log: mock.fn(),
+    error: mock.fn(),
+  };
+
+  config = {
+    endpoint: 'https://happo.io',
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+    project: 'test-project',
+    githubApiUrl: 'https://api.github.com',
+    targets: {},
+    integration: {
+      type: 'custom',
+      build: async () => ({
+        rootDir: './custom',
+        entryPoint: 'index.js',
+      }),
+    },
+  };
+
+  environment = {
+    beforeSha: 'before-sha',
+    afterSha: 'after-sha',
+    link: 'https://example.com',
+    message: 'test-message',
+    authorEmail: 'test@example.com',
+    nonce: 'test-nonce',
+    debugMode: false,
+    notify: 'test@example.com',
+    fallbackShas: ['test-sha'],
+    githubToken: 'test-token',
+    ci: false,
+  };
+
+  makeHappoAPIRequestImpl = async () => {
+    throw new Error('makeHappoAPIRequest not configured');
+  };
+
+  ({ default: cancelJob } = await import('../cancelJob.ts'));
+
+  makeHappoAPIRequestMock.mock.resetCalls();
+});
+
+describe('cancelJob', () => {
+  it('logs and ignores when job is already completed', async () => {
+    makeHappoAPIRequestImpl = async () => {
+      throw new ErrorWithStatusCode('Conflict', 409);
+    };
+
+    await assert.doesNotReject(
+      cancelJob('failure', 'test-message', config, environment, logger),
+    );
+
+    assert.strictEqual(logger.error.mock.callCount(), 1);
+    assert.strictEqual(
+      logger.error.mock.calls[0]?.arguments[0],
+      'Skipping cancellation of Happo job because it has already been completed',
+    );
+  });
+
+  it('logs and ignores when job does not exist', async () => {
+    makeHappoAPIRequestImpl = async () => {
+      throw new ErrorWithStatusCode('No job found', 404);
+    };
+
+    await assert.doesNotReject(
+      cancelJob('failure', 'test-message', config, environment, logger),
+    );
+
+    assert.strictEqual(logger.error.mock.callCount(), 1);
+    assert.strictEqual(
+      logger.error.mock.calls[0]?.arguments[0],
+      'Skipping cancellation of Happo job because it does not exist',
+    );
+  });
+
+  it('throws when job does not exist but message is different', async () => {
+    makeHappoAPIRequestImpl = async () => {
+      throw new ErrorWithStatusCode('Other message', 404);
+    };
+
+    await assert.rejects(
+      cancelJob('failure', 'test-message', config, environment, logger),
+    );
+  });
+
+  it('throws for unexpected errors', async () => {
+    makeHappoAPIRequestImpl = async () => {
+      throw new Error('boom');
+    };
+
+    await assert.rejects(
+      cancelJob('failure', 'test-message', config, environment, logger),
+    );
+  });
+});

--- a/src/network/cancelJob.ts
+++ b/src/network/cancelJob.ts
@@ -43,6 +43,15 @@ export default async function cancelJob(
         'Skipping cancellation of Happo job because it has already been completed',
         error,
       );
+    } else if (
+      error instanceof ErrorWithStatusCode &&
+      error.statusCode === 404 &&
+      error.message.includes('No job found')
+    ) {
+      logger.error(
+        'Skipping cancellation of Happo job because it does not exist',
+        error,
+      );
     } else {
       throw error;
     }

--- a/src/network/startJob.ts
+++ b/src/network/startJob.ts
@@ -3,7 +3,7 @@ import type { EnvironmentResult } from '../environment/index.ts';
 import type { Logger } from '../isomorphic/types.ts';
 import makeHappoAPIRequest from './makeHappoAPIRequest.ts';
 
-interface StartJobResult {
+export interface StartJobResult {
   id: number;
   url: string;
 }


### PR DESCRIPTION
Before this change, we would wait with initializing the job until the e2e test suite was finished. This would result in the cancel job call (which happens when the wrapped command fails) 404-ing. To fix this, I'm making the following changes:

- Start the job as soon as possible
- Use the `startJob`/`cancelJob` modules instead of making custom API calls
- Don't retry cancelling jobs if the API responds with a 404