### PR TITLE
Fix focusing active element in Cypress

### DIFF
--- a/happoconfigs/happo.config.ts
+++ b/happoconfigs/happo.config.ts
@@ -11,16 +11,19 @@ const config: Config = defineConfig({
     chrome: {
       type: 'chrome',
       viewport: '1024x768',
+      applyPseudoClasses: true,
     },
 
     chromeSmall: {
       type: 'chrome',
       viewport: '375x667',
+      applyPseudoClasses: true,
     },
 
     accessibility: {
       type: 'accessibility',
       viewport: '375x667',
+      applyPseudoClasses: true,
     },
   },
 });

--- a/src/browser/__tests__/assertElement.test.ts
+++ b/src/browser/__tests__/assertElement.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
 import withJSDOM from '../../test-utils/withJSDOM.ts';
-import assertElement from '../assertElement.ts';
+import assertElement, { isElementWithDataset } from '../assertElement.ts';
 
 const initDOM = withJSDOM();
 
@@ -105,5 +105,35 @@ describe('assertElement', () => {
     iframe.contentDocument.body.append(textNode);
     const nodeList = iframe.contentDocument.body.childNodes;
     assert.throws(() => assertElement(nodeList));
+  });
+});
+
+
+describe('isElementWithDataset', () => {
+  it('returns true if the element is an HTMLElement', () => {
+    initDOM('<!DOCTYPE html>');
+    const { document: doc } = globalThis.window;
+    const element = doc.createElement('div');
+    assert.equal(isElementWithDataset(element), true);
+  });
+
+  it('returns true if the element is an SVGElement', () => {
+    initDOM('<!DOCTYPE html>');
+    const { document: doc } = globalThis.window;
+    const element = doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    assert.equal(isElementWithDataset(element), true);
+  });
+
+  it('returns true if the element is an MathMLElement', () => {
+    initDOM('<!DOCTYPE html>');
+    const { document: doc } = globalThis.window;
+    const element = doc.createElement('math');
+    assert.equal(isElementWithDataset(element), true);
+  });
+
+  it('returns false if the element does not have a dataset', () => {
+    initDOM('<!DOCTYPE html>');
+    const { document: doc } = globalThis.window;
+    assert.equal(isElementWithDataset(doc.createTextNode('text node')), false);
   });
 });

--- a/src/browser/assertElement.ts
+++ b/src/browser/assertElement.ts
@@ -1,4 +1,30 @@
-function isIterableCollection(
+export function isElementWithDataset(
+  element: unknown,
+): element is HTMLElement | SVGElement | MathMLElement {
+  if (typeof element !== 'object') {
+    return false;
+  }
+
+  if (element == null) {
+    return false;
+  }
+
+  if (!('dataset' in element)) {
+    return false;
+  }
+
+  if (typeof element.dataset !== 'object') {
+    return false;
+  }
+
+  if (element.dataset == null) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isIterableCollection(
   element: NonNullable<unknown>,
 ): element is Iterable<unknown> {
   if (typeof element !== 'object') {

--- a/src/config/openBrowser.ts
+++ b/src/config/openBrowser.ts
@@ -20,4 +20,3 @@ export default function openBrowser(url: string): Promise<void> {
     // Ignore errors - browser might not open, but that's okay
   });
 }
-

--- a/src/config/promptUser.ts
+++ b/src/config/promptUser.ts
@@ -18,4 +18,3 @@ export default function promptUser(message: string): Promise<void> {
     });
   });
 }
-

--- a/src/cypress/__cypress__/fixtures/index.html
+++ b/src/cypress/__cypress__/fixtures/index.html
@@ -1,5 +1,13 @@
 <!doctype html>
 <html>
+  <head>
+    <title>Happo spec</title>
+    <style>
+      button:focus {
+        background-color: blue;
+      }
+    </style>
+  </head>
   <body>
     <main>
       <h1>Hello world</h1>

--- a/src/cypress/__cypress__/tests/happo.spec.ts
+++ b/src/cypress/__cypress__/tests/happo.spec.ts
@@ -1,6 +1,19 @@
 describe('happo spec', () => {
   it('passes', () => {
     cy.visit(`http://localhost:${Cypress.env('SERVER_PORT')}/index.html`);
+
+    cy.get('main').happoScreenshot({
+      component: 'main',
+      variant: 'default',
+    });
+
+    cy.get('button').first().focus();
+    cy.get('main').happoScreenshot({
+      component: 'main',
+      variant: 'button focused',
+    });
+    cy.get('button').first().blur();
+
     cy.get('h1').happoScreenshot({
       component: 'h1',
       variant: 'default',

--- a/src/e2e/__tests__/createAssetPackage.test.ts
+++ b/src/e2e/__tests__/createAssetPackage.test.ts
@@ -52,7 +52,7 @@ describe('createAssetPackage', () => {
         'sub folder/countries-bg.jpeg',
       ].toSorted(),
     );
-    assert.equal(pkg.hash, '6bfbf5cafbb71da0dac6bf083bc26a57');
+    assert.equal(pkg.hash, '1144340b24e1a9ca500a9f02befc5a61');
   });
 
   it('includes external assets when downloadAllAssets is true', async () => {

--- a/src/e2e/__tests__/fixtures/foo.html
+++ b/src/e2e/__tests__/fixtures/foo.html
@@ -1,3 +1,5 @@
 <html>
-  <body>Hello world</body>
+  <body>
+    Hello world
+  </body>
 </html>

--- a/src/utils/__tests__/validateArchive.test.ts
+++ b/src/utils/__tests__/validateArchive.test.ts
@@ -3,7 +3,6 @@ import { describe, it } from 'node:test';
 
 import validateArchive from '../validateArchive.ts';
 
-
 describe('validateArchive', () => {
   it('does not throw when totalBytes is lower than 30 MB', () => {
     assert.strictEqual(validateArchive(100, []), undefined);


### PR DESCRIPTION
This is the same issue we fixed in
https://github.com/happo/happo/pull/360 but in a different spot.

Since we have a reference to the document here, I considered using `doc.defaultView.HTMLElement` for the `instanceof` checks, but I thought the approach I landed on would be more broadly applicable since it doesn't rely on `instanceof` at all.

While I was at it, I removed some other uses of `instanceof` in this file.

More info:

https://glebbahmutov.com/cypress-examples/recipes/instanceof.html

Fixes #367