### PR TITLE
Add --skip CLI argument for partial runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           happo-api-key: ${{ secrets.HAPPO_API_KEY }}
           happo-api-secret: ${{ secrets.HAPPO_API_SECRET }}
-          projects: 'cypress,storybook-v9,storybook-v10,playwright,playwright-nonce,custom,pages'
+          projects: 'cypress,storybook-v9,storybook-v10,storybook-skipped,playwright,playwright-nonce,custom,pages'
 
   cypress:
     runs-on: ubuntu-latest
@@ -86,6 +86,14 @@ jobs:
       - run: pnpm test:storybook
         env:
           HAPPO_STORYBOOK_VERSION: ${{ matrix.version }}
+
+  storybook-skipped:
+    runs-on: ubuntu-latest
+    name: Storybook (skipped examples)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-env
+      - run: pnpm test:storybook:skipped
 
   playwright:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
       - uses: ./.github/actions/setup-env
       - if: matrix.dependencies != ''
         run: pnpm add -D ${{ matrix.dependencies }}
-      - run: pnpm test:storybook
+      - run: pnpm test:storybook -- --skippedExamples "$(node ./scripts/getSkippedExamples.ts)"
         env:
           HAPPO_STORYBOOK_VERSION: ${{ matrix.version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
       - uses: ./.github/actions/setup-env
       - if: matrix.dependencies != ''
         run: pnpm add -D ${{ matrix.dependencies }}
-      - run: pnpm test:storybook -- --skippedExamples "$(node ./scripts/getSkippedExamples.ts)"
+      - run: pnpm build:dist && node dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --skippedExamples "$(node ./scripts/getSkippedExamples.ts)"
         env:
           HAPPO_STORYBOOK_VERSION: ${{ matrix.version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
       - uses: ./.github/actions/setup-env
       - if: matrix.dependencies != ''
         run: pnpm add -D ${{ matrix.dependencies }}
-      - run: pnpm build:dist && node dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --skippedExamples "$(node ./scripts/getSkippedExamples.ts)"
+      - run: pnpm test:storybook
         env:
           HAPPO_STORYBOOK_VERSION: ${{ matrix.version }}
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "test:playwright": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright.config.ts e2e -- playwright test",
     "test:playwright:nonce": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE e2e -- playwright test && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE finalize",
     "test:storybook": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts",
+    "test:storybook:skipped": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --skippedExamples \"$(node ./scripts/getSkippedExamples.ts)\"",
     "test:pages": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.pages.config.ts",
     "tsc": "tsc --build tsconfig.json"
   },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "test:playwright": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright.config.ts e2e -- playwright test",
     "test:playwright:nonce": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE e2e -- playwright test && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE finalize",
     "test:storybook": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts",
-    "test:storybook:skipped": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-skipped --skippedExamples \"$(node ./scripts/getSkippedExamples.ts)\"",
+    "test:storybook:skipped": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-skipped --skip \"$(node ./scripts/getSkip.ts)\"",
     "test:pages": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.pages.config.ts",
     "tsc": "tsc --build tsconfig.json"
   },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "test:playwright": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright.config.ts e2e -- playwright test",
     "test:playwright:nonce": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE e2e -- playwright test && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE finalize",
     "test:storybook": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts",
-    "test:storybook:skipped": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --skippedExamples \"$(node ./scripts/getSkippedExamples.ts)\"",
+    "test:storybook:skipped": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-skipped --skippedExamples \"$(node ./scripts/getSkippedExamples.ts)\"",
     "test:pages": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.pages.config.ts",
     "tsc": "tsc --build tsconfig.json"
   },

--- a/scripts/getSkip.ts
+++ b/scripts/getSkip.ts
@@ -1,10 +1,10 @@
 /**
- * Outputs a --skippedExamples JSON argument, cycling through a set of
- * examples based on the current day of the week so that a different example
- * is skipped on each day.
+ * Outputs a --skip JSON argument, cycling through a set of examples based on
+ * the current day of the week so that a different example is skipped on each
+ * day.
  *
  * Usage:
- *   node scripts/getSkippedExamples.ts
+ *   node scripts/getSkip.ts
  */
 
 const examples = [

--- a/scripts/getSkippedExamples.ts
+++ b/scripts/getSkippedExamples.ts
@@ -1,0 +1,23 @@
+/**
+ * Outputs a --partial JSON argument for a storybook partial run, cycling
+ * through a set of examples based on the current day of the week so that a
+ * different example is skipped on each day.
+ *
+ * Usage:
+ *   node scripts/getPartialExamples.ts
+ */
+
+const examples = [
+  { component: 'Stories', variant: 'ButtonWithText' },
+  { component: 'Stories', variant: 'MiscLarge' },
+  { component: 'Stories', variant: 'ButtonFirefoxOnly' },
+  { component: 'Stories', variant: 'Portal' },
+  { component: 'Stories', variant: 'ButtonWithImage' },
+  { component: 'Stories', variant: 'ButtonWithSomeEmoji' },
+  { component: 'Stories', variant: 'Lazy' },
+];
+
+const day = new Date().getDay(); // 0 (Sun) – 6 (Sat)
+const skipped = examples[day % examples.length];
+
+process.stdout.write(JSON.stringify([skipped]));

--- a/scripts/getSkippedExamples.ts
+++ b/scripts/getSkippedExamples.ts
@@ -8,12 +8,12 @@
  */
 
 const examples = [
-  { component: 'Stories', variant: 'ButtonWithText [white]' },
-  { component: 'Stories', variant: 'MiscLarge [white]' },
-  { component: 'Stories', variant: 'ButtonFirefoxOnly [white]' },
+  { component: 'Stories', variant: 'Button With Text [white]' },
+  { component: 'Stories', variant: 'Misc Large [white]' },
+  { component: 'Stories', variant: 'Button Firefox Only [white]' },
   { component: 'Stories', variant: 'Portal [white]' },
-  { component: 'Stories', variant: 'ButtonWithImage [white]' },
-  { component: 'Stories', variant: 'ButtonWithSomeEmoji [white]' },
+  { component: 'Stories', variant: 'Button With Image [white]' },
+  { component: 'Stories', variant: 'Button With Some Emoji [white]' },
   { component: 'Stories', variant: 'Lazy [white]' },
 ];
 

--- a/scripts/getSkippedExamples.ts
+++ b/scripts/getSkippedExamples.ts
@@ -1,10 +1,10 @@
 /**
- * Outputs a --partial JSON argument for a storybook partial run, cycling
- * through a set of examples based on the current day of the week so that a
- * different example is skipped on each day.
+ * Outputs a --skippedExamples JSON argument, cycling through a set of
+ * examples based on the current day of the week so that a different example
+ * is skipped on each day.
  *
  * Usage:
- *   node scripts/getPartialExamples.ts
+ *   node scripts/getSkippedExamples.ts
  */
 
 const examples = [

--- a/scripts/getSkippedExamples.ts
+++ b/scripts/getSkippedExamples.ts
@@ -8,13 +8,13 @@
  */
 
 const examples = [
-  { component: 'Stories', variant: 'ButtonWithText' },
-  { component: 'Stories', variant: 'MiscLarge' },
-  { component: 'Stories', variant: 'ButtonFirefoxOnly' },
-  { component: 'Stories', variant: 'Portal' },
-  { component: 'Stories', variant: 'ButtonWithImage' },
-  { component: 'Stories', variant: 'ButtonWithSomeEmoji' },
-  { component: 'Stories', variant: 'Lazy' },
+  { component: 'Stories', variant: 'ButtonWithText [white]' },
+  { component: 'Stories', variant: 'MiscLarge [white]' },
+  { component: 'Stories', variant: 'ButtonFirefoxOnly [white]' },
+  { component: 'Stories', variant: 'Portal [white]' },
+  { component: 'Stories', variant: 'ButtonWithImage [white]' },
+  { component: 'Stories', variant: 'ButtonWithSomeEmoji [white]' },
+  { component: 'Stories', variant: 'Lazy [white]' },
 ];
 
 const day = new Date().getDay(); // 0 (Sun) – 6 (Sat)

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -803,8 +803,8 @@ describe('main', () => {
         assert(makeHappoAPIRequestMock.mock.callCount() > 0);
       });
 
-      it('sends skippedExamples in the finalize request body when --skippedExamples is set', async () => {
-        const skippedExamples = [
+      it('sends skip in the finalize request body when --skip is set', async () => {
+        const skip = [
           { component: 'Button', variant: 'primary', target: 'chrome' },
         ];
         await main(
@@ -818,8 +818,8 @@ describe('main', () => {
             'test-sha',
             '--nonce',
             'test-nonce',
-            '--skippedExamples',
-            JSON.stringify(skippedExamples),
+            '--skip',
+            JSON.stringify(skip),
           ],
           logger,
         );
@@ -829,13 +829,13 @@ describe('main', () => {
         );
         assert.ok(finalizeCall, 'expected a finalize API call');
         assert.deepStrictEqual(
-          (finalizeCall.arguments[0]?.body as { skippedExamples: unknown })
-            ?.skippedExamples,
-          skippedExamples,
+          (finalizeCall.arguments[0]?.body as { skip: unknown })
+            ?.skip,
+          skip,
         );
       });
 
-      it('sends an empty skippedExamples array when --skippedExamples is not set', async () => {
+      it('sends an empty skip array when --skip is not set', async () => {
         await main(
           [
             'npx',
@@ -856,8 +856,8 @@ describe('main', () => {
         );
         assert.ok(finalizeCall, 'expected a finalize API call');
         assert.deepStrictEqual(
-          (finalizeCall.arguments[0]?.body as { skippedExamples: unknown })
-            ?.skippedExamples,
+          (finalizeCall.arguments[0]?.body as { skip: unknown })
+            ?.skip,
           [],
         );
       });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import type { ConfigWithDefaults } from '../config/index.ts';
 import { findConfigFile, loadConfigFile } from '../config/loadConfig.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
 import resolveEnvironment from '../environment/index.ts';
+import { validateSkippedExamples } from '../isomorphic/parseSkippedExamples.ts';
 import type { Logger, SkipItem } from '../isomorphic/types.ts';
 import type { ParsedCLIArgs } from './parseOptions.ts';
 import { parseOptions } from './parseOptions.ts';
@@ -244,29 +245,12 @@ export async function main(
     if (args.dashdashCommandParts) {
       let validatedSkippedExamplesJSON: string | undefined;
       if (environment.skippedExamples) {
-        let parsed: unknown;
         try {
-          parsed = JSON.parse(environment.skippedExamples);
+          validateSkippedExamples(environment.skippedExamples);
         } catch (e) {
-          logger.error('[HAPPO] Failed to parse --skippedExamples JSON:', e);
-          process.exitCode = 1;
-          return;
-        }
-        if (
-          !Array.isArray(parsed) ||
-          !parsed.every(
-            (item) => {
-              if (typeof item !== 'object' || item === null) return false;
-              const r = item as Record<string, unknown>;
-              return (
-                typeof r.component === 'string' &&
-                (r.variant === undefined || typeof r.variant === 'string')
-              );
-            },
-          )
-        ) {
           logger.error(
-            '[HAPPO] --skippedExamples must be a JSON array of {component, variant?} objects',
+            '[HAPPO] Invalid --skippedExamples:',
+            e instanceof Error ? e.message : String(e),
           );
           process.exitCode = 1;
           return;
@@ -373,34 +357,16 @@ async function handleDefaultCommand(
         return;
       }
 
-      let parsed: unknown;
       try {
-        parsed = JSON.parse(environment.skippedExamples);
+        skippedExamples = validateSkippedExamples(environment.skippedExamples);
       } catch (e) {
-        logger.error('[HAPPO] Failed to parse --skippedExamples JSON:', e);
-        process.exitCode = 1;
-        return;
-      }
-
-      if (
-        !Array.isArray(parsed) ||
-        !parsed.every((item): item is SkipItem => {
-          if (typeof item !== 'object' || item === null) return false;
-          const r = item as Record<string, unknown>;
-          return (
-            typeof r.component === 'string' &&
-            (r.variant === undefined || typeof r.variant === 'string')
-          );
-        })
-      ) {
         logger.error(
-          '[HAPPO] --skippedExamples must be a JSON array of {component, variant?} objects',
+          '[HAPPO] Invalid --skippedExamples:',
+          e instanceof Error ? e.message : String(e),
         );
         process.exitCode = 1;
         return;
       }
-
-      skippedExamples = parsed;
 
       const findBaselineReport = (
         await import('../network/findBaselineReport.ts')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -255,15 +255,18 @@ export async function main(
         if (
           !Array.isArray(parsed) ||
           !parsed.every(
-            (item) =>
-              typeof item === 'object' &&
-              item !== null &&
-              typeof (item as Record<string, unknown>).component === 'string' &&
-              typeof (item as Record<string, unknown>).variant === 'string',
+            (item) => {
+              if (typeof item !== 'object' || item === null) return false;
+              const r = item as Record<string, unknown>;
+              return (
+                typeof r.component === 'string' &&
+                (r.variant === undefined || typeof r.variant === 'string')
+              );
+            },
           )
         ) {
           logger.error(
-            '[HAPPO] --skippedExamples must be a JSON array of {component, variant} objects',
+            '[HAPPO] --skippedExamples must be a JSON array of {component, variant?} objects',
           );
           process.exitCode = 1;
           return;
@@ -381,16 +384,17 @@ async function handleDefaultCommand(
 
       if (
         !Array.isArray(parsed) ||
-        !parsed.every(
-          (item): item is SkipItem =>
-            typeof item === 'object' &&
-            item !== null &&
-            typeof (item as Record<string, unknown>).component === 'string' &&
-            typeof (item as Record<string, unknown>).variant === 'string',
-        )
+        !parsed.every((item): item is SkipItem => {
+          if (typeof item !== 'object' || item === null) return false;
+          const r = item as Record<string, unknown>;
+          return (
+            typeof r.component === 'string' &&
+            (r.variant === undefined || typeof r.variant === 'string')
+          );
+        })
       ) {
         logger.error(
-          '[HAPPO] --skippedExamples must be a JSON array of {component, variant} objects',
+          '[HAPPO] --skippedExamples must be a JSON array of {component, variant?} objects',
         );
         process.exitCode = 1;
         return;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@ import type { ConfigWithDefaults } from '../config/index.ts';
 import { findConfigFile, loadConfigFile } from '../config/loadConfig.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
 import resolveEnvironment from '../environment/index.ts';
-import type { Logger } from '../isomorphic/types.ts';
+import type { Logger, SkipItem } from '../isomorphic/types.ts';
 import type { ParsedCLIArgs } from './parseOptions.ts';
 import { parseOptions } from './parseOptions.ts';
 import type { Reporter } from './telemetry.ts';
@@ -127,6 +127,7 @@ Options:
   --notify <emails>     One or more (comma-separated) email addresses to notify with results
   --nonce <nonce>       Nonce to use for Cypress/Playwright comparison
   --githubToken <token> GitHub token to use for posting Happo statuses as comments. Use in combination with the \`githubApiUrl\` configuration option. (default: auto-detected from environment)
+  --skippedExamples <json> JSON array of {component, variant} objects to skip in this run and borrow from the nearest baseline report instead
 
 Flake command options:
   --allProjects         List flakes across all projects (default: current project)
@@ -155,7 +156,7 @@ Examples:
 
   happo -- playwright test
 
-  --skippedExamples <json>  JSON array of examples to skip in the finalize command (e.g. '[{"component":"Button","variant":"primary","target":"chrome"}]')
+  happo --skippedExamples '[{"component":"Button","variant":"Primary"}]'
 
   happo finalize
   happo finalize --nonce my-unique-nonce
@@ -243,6 +244,7 @@ export async function main(
         args.dashdashCommandParts,
         configFilePath,
         logger,
+        environment.skippedExamples,
       );
       return;
     }
@@ -321,13 +323,54 @@ async function handleDefaultCommand(
   await startJob(config, environment, logger);
 
   try {
+    // When --skippedExamples is set, first resolve the baseline SHA. If no
+    // baseline is found we fall back to a full run (no skipping).
+    let skippedExamples: Array<SkipItem> | undefined;
+    let baselineSha: string | undefined;
+
+    if (environment.skippedExamples) {
+      try {
+        skippedExamples = JSON.parse(environment.skippedExamples) as Array<SkipItem>;
+      } catch (e) {
+        logger.error('[HAPPO] Failed to parse --skippedExamples JSON:', e);
+        process.exitCode = 1;
+        return;
+      }
+
+      const findBaselineReport = (
+        await import('../network/findBaselineReport.ts')
+      ).default;
+      baselineSha = await findBaselineReport(environment, config, logger);
+      if (!baselineSha) {
+        logger.log(
+          '[HAPPO] No baseline report found for --skippedExamples run. Generating a full report instead.',
+        );
+        skippedExamples = undefined;
+      }
+    }
+
     // Prepare the snap requests for the job. This includes bundling static
-    // assets and uploading them.
-    const snapRequestIds = await prepareSnapRequests(config);
+    // assets and uploading them. Only pass the skip list when we have a
+    // baseline to borrow the skipped examples from.
+    const snapRequestIds = await prepareSnapRequests(config, skippedExamples);
+
+    let allSnapRequestIds = snapRequestIds;
+
+    if (skippedExamples && baselineSha) {
+      const createExtendsReportSnapRequest = (
+        await import('../network/createExtendsReportSnapRequest.ts')
+      ).default;
+      const extendsRequestId = await createExtendsReportSnapRequest(
+        baselineSha,
+        skippedExamples,
+        config,
+      );
+      allSnapRequestIds = [...snapRequestIds, extendsRequestId];
+    }
 
     // Put together a report from the snap requests.
     const asyncReport = await createAsyncReport(
-      snapRequestIds,
+      allSnapRequestIds,
       config,
       environment,
       logger,
@@ -460,6 +503,7 @@ async function handleE2ECommand(
   dashdashCommandParts: Array<string>,
   configFilePath: string,
   logger: Logger,
+  skippedExamplesJSON?: string,
 ): Promise<void> {
   if (!E2E_INTEGRATION_TYPES.includes(config.integration.type)) {
     logger.error(
@@ -488,6 +532,7 @@ async function handleE2ECommand(
     environment,
     logger,
     configFilePath,
+    skippedExamplesJSON,
   );
   process.exitCode = exitCode;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@ import type { ConfigWithDefaults } from '../config/index.ts';
 import { findConfigFile, loadConfigFile } from '../config/loadConfig.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
 import resolveEnvironment from '../environment/index.ts';
-import { validateSkippedExamples } from '../isomorphic/parseSkippedExamples.ts';
+import { validateSkip } from '../isomorphic/parseSkip.ts';
 import type { Logger, SkipItem } from '../isomorphic/types.ts';
 import type { ParsedCLIArgs } from './parseOptions.ts';
 import { parseOptions } from './parseOptions.ts';
@@ -128,7 +128,7 @@ Options:
   --notify <emails>     One or more (comma-separated) email addresses to notify with results
   --nonce <nonce>       Nonce to use for Cypress/Playwright comparison
   --githubToken <token> GitHub token to use for posting Happo statuses as comments. Use in combination with the \`githubApiUrl\` configuration option. (default: auto-detected from environment)
-  --skippedExamples <json> JSON array of {component, variant} objects to skip in this run and borrow from the nearest baseline report instead
+  --skip <json> JSON array of {component, variant} objects to skip in this run and borrow from the nearest baseline report instead
 
 Flake command options:
   --allProjects         List flakes across all projects (default: current project)
@@ -157,11 +157,11 @@ Examples:
 
   happo -- playwright test
 
-  happo --skippedExamples '[{"component":"Button","variant":"Primary"}]'
+  happo --skip '[{"component":"Button","variant":"Primary"}]'
 
   happo finalize
   happo finalize --nonce my-unique-nonce
-  happo finalize --skippedExamples '[{"component":"Button","variant":"primary","target":"chrome"}]'
+  happo finalize --skip '[{"component":"Button","variant":"primary","target":"chrome"}]'
 
   happo flake
   happo flake --allProjects
@@ -243,19 +243,19 @@ export async function main(
     const command = args.positionals[0];
 
     if (args.dashdashCommandParts) {
-      let validatedSkippedExamplesJSON: string | undefined;
-      if (environment.skippedExamples) {
+      let validatedSkipJSON: string | undefined;
+      if (environment.skip) {
         try {
-          validateSkippedExamples(environment.skippedExamples);
+          validateSkip(environment.skip);
         } catch (e) {
           logger.error(
-            '[HAPPO] Invalid --skippedExamples:',
+            '[HAPPO] Invalid --skip:',
             e instanceof Error ? e.message : String(e),
           );
           process.exitCode = 1;
           return;
         }
-        validatedSkippedExamplesJSON = environment.skippedExamples;
+        validatedSkipJSON = environment.skip;
       }
       await handleE2ECommand(
         config,
@@ -263,7 +263,7 @@ export async function main(
         args.dashdashCommandParts,
         configFilePath,
         logger,
-        validatedSkippedExamplesJSON,
+        validatedSkipJSON,
       );
       return;
     }
@@ -342,26 +342,26 @@ async function handleDefaultCommand(
   await startJob(config, environment, logger);
 
   try {
-    // When --skippedExamples is set, first resolve the baseline SHA. If no
+    // When --skip is set, first resolve the baseline SHA. If no
     // baseline is found we fall back to a full run (no skipping).
-    let skippedExamples: Array<SkipItem> | undefined;
+    let skip: Array<SkipItem> | undefined;
     let baselineSha: string | undefined;
 
-    if (environment.skippedExamples) {
+    if (environment.skip) {
       const supportedTypes = ['storybook', 'custom'];
       if (!supportedTypes.includes(config.integration.type)) {
         logger.error(
-          `[HAPPO] --skippedExamples is not supported for integration type '${config.integration.type}'. Supported types: ${supportedTypes.join(', ')}`,
+          `[HAPPO] --skip is not supported for integration type '${config.integration.type}'. Supported types: ${supportedTypes.join(', ')}`,
         );
         process.exitCode = 1;
         return;
       }
 
       try {
-        skippedExamples = validateSkippedExamples(environment.skippedExamples);
+        skip = validateSkip(environment.skip);
       } catch (e) {
         logger.error(
-          '[HAPPO] Invalid --skippedExamples:',
+          '[HAPPO] Invalid --skip:',
           e instanceof Error ? e.message : String(e),
         );
         process.exitCode = 1;
@@ -374,26 +374,26 @@ async function handleDefaultCommand(
       baselineSha = await findBaselineReport(environment, config, logger);
       if (!baselineSha) {
         logger.log(
-          '[HAPPO] No baseline report found for --skippedExamples run. Generating a full report instead.',
+          '[HAPPO] No baseline report found for --skip run. Generating a full report instead.',
         );
-        skippedExamples = undefined;
+        skip = undefined;
       }
     }
 
     // Prepare the snap requests for the job. This includes bundling static
     // assets and uploading them. Only pass the skip list when we have a
     // baseline to borrow the skipped examples from.
-    const snapRequestIds = await prepareSnapRequests(config, skippedExamples);
+    const snapRequestIds = await prepareSnapRequests(config, skip);
 
     let allSnapRequestIds = snapRequestIds;
 
-    if (skippedExamples && baselineSha) {
+    if (skip && baselineSha) {
       const createExtendsReportSnapRequest = (
         await import('../network/createExtendsReportSnapRequest.ts')
       ).default;
       const extendsRequestId = await createExtendsReportSnapRequest(
         baselineSha,
-        skippedExamples,
+        skip,
         config,
       );
       allSnapRequestIds = [...snapRequestIds, extendsRequestId];
@@ -534,7 +534,7 @@ async function handleE2ECommand(
   dashdashCommandParts: Array<string>,
   configFilePath: string,
   logger: Logger,
-  skippedExamplesJSON?: string,
+  skipJSON?: string,
 ): Promise<void> {
   if (!E2E_INTEGRATION_TYPES.includes(config.integration.type)) {
     logger.error(
@@ -563,7 +563,7 @@ async function handleE2ECommand(
     environment,
     logger,
     configFilePath,
-    skippedExamplesJSON,
+    skipJSON,
   );
   process.exitCode = exitCode;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -242,13 +242,41 @@ export async function main(
     const command = args.positionals[0];
 
     if (args.dashdashCommandParts) {
+      let validatedSkippedExamplesJSON: string | undefined;
+      if (environment.skippedExamples) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(environment.skippedExamples);
+        } catch (e) {
+          logger.error('[HAPPO] Failed to parse --skippedExamples JSON:', e);
+          process.exitCode = 1;
+          return;
+        }
+        if (
+          !Array.isArray(parsed) ||
+          !parsed.every(
+            (item) =>
+              typeof item === 'object' &&
+              item !== null &&
+              typeof (item as Record<string, unknown>).component === 'string' &&
+              typeof (item as Record<string, unknown>).variant === 'string',
+          )
+        ) {
+          logger.error(
+            '[HAPPO] --skippedExamples must be a JSON array of {component, variant} objects',
+          );
+          process.exitCode = 1;
+          return;
+        }
+        validatedSkippedExamplesJSON = environment.skippedExamples;
+      }
       await handleE2ECommand(
         config,
         environment,
         args.dashdashCommandParts,
         configFilePath,
         logger,
-        environment.skippedExamples,
+        validatedSkippedExamplesJSON,
       );
       return;
     }
@@ -333,13 +361,42 @@ async function handleDefaultCommand(
     let baselineSha: string | undefined;
 
     if (environment.skippedExamples) {
+      const supportedTypes = ['storybook', 'custom'];
+      if (!supportedTypes.includes(config.integration.type)) {
+        logger.error(
+          `[HAPPO] --skippedExamples is not supported for integration type '${config.integration.type}'. Supported types: ${supportedTypes.join(', ')}`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      let parsed: unknown;
       try {
-        skippedExamples = JSON.parse(environment.skippedExamples) as Array<SkipItem>;
+        parsed = JSON.parse(environment.skippedExamples);
       } catch (e) {
         logger.error('[HAPPO] Failed to parse --skippedExamples JSON:', e);
         process.exitCode = 1;
         return;
       }
+
+      if (
+        !Array.isArray(parsed) ||
+        !parsed.every(
+          (item): item is SkipItem =>
+            typeof item === 'object' &&
+            item !== null &&
+            typeof (item as Record<string, unknown>).component === 'string' &&
+            typeof (item as Record<string, unknown>).variant === 'string',
+        )
+      ) {
+        logger.error(
+          '[HAPPO] --skippedExamples must be a JSON array of {component, variant} objects',
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      skippedExamples = parsed;
 
       const findBaselineReport = (
         await import('../network/findBaselineReport.ts')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -234,6 +234,10 @@ export async function main(
     const configFilePath = makeAbsolute(args.values.config || findConfigFile());
     const config = await loadConfigFile(configFilePath, environment, logger);
 
+    if (args.values.project !== undefined) {
+      config.project = args.values.project;
+    }
+
     // Handle positional arguments (commands)
     const command = args.positionals[0];
 

--- a/src/cli/parseOptions.ts
+++ b/src/cli/parseOptions.ts
@@ -101,7 +101,7 @@ export const parseOptions = {
     type: 'string',
   },
 
-  skippedExamples: {
+  skip: {
     type: 'string',
   },
 } as const;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,3 @@
-import type { SkipItems } from '../storybook/isomorphic/types.ts';
-
 export interface StorybookIntegration {
   type: 'storybook';
 
@@ -23,14 +21,6 @@ export interface StorybookIntegration {
    * sure that files are built to the outputDir.
    */
   usePrebuiltPackage?: boolean;
-
-  /**
-   * Items to skip when generating snapshots.
-   *
-   * Can be an async function that resolves to an array of `{component,
-   * variant}`, or an array of `{component, variant}`.
-   */
-  skip?: SkipItems | (() => Promise<SkipItems>) | undefined;
 }
 
 interface BaseE2EIntegration {

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -1,8 +1,8 @@
 import {
   isInSkipSet,
-  parseSkippedExamples,
+  parseSkip,
   toSkipSet,
-} from '../isomorphic/parseSkippedExamples.ts';
+} from '../isomorphic/parseSkip.ts';
 import type { NextExampleResult, WindowWithHappo } from '../isomorphic/types.ts';
 
 interface HappoStaticExample extends NextExampleResult {
@@ -52,7 +52,7 @@ const happoStatic = {
             ? null
             : document.getElementById('happo-skipped');
         const skipSet = toSkipSet(
-          parseSkippedExamples(happoSkippedEl?.textContent ?? undefined),
+          parseSkip(happoSkippedEl?.textContent ?? undefined),
         );
 
         while (true) {

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -42,26 +42,41 @@ const happoStatic = {
       },
 
       nextExample: async () => {
-        const example = examples[currentIndex];
+        const happoSkipped = (globalThis as { happoSkipped?: Array<{ component: string; variant: string }> }).happoSkipped;
 
-        if (!example) {
-          // we're done
-          return;
+        while (true) {
+          const example = examples[currentIndex];
+
+          if (!example) {
+            // we're done
+            return;
+          }
+
+          if (
+            Array.isArray(happoSkipped) &&
+            happoSkipped.some(
+              (item) =>
+                item.component === example.component && item.variant === example.variant,
+            )
+          ) {
+            currentIndex++;
+            continue;
+          }
+
+          if (example.render) {
+            await example.render();
+          }
+          currentIndex++;
+
+          const clone = {
+            component: example.component,
+            variant: example.variant,
+            targets: example.targets,
+            waitForContent: example.waitForContent,
+          };
+
+          return clone;
         }
-
-        if (example.render) {
-          await example.render();
-        }
-        currentIndex++;
-
-        const clone = {
-          component: example.component,
-          variant: example.variant,
-          targets: example.targets,
-          waitForContent: example.waitForContent,
-        };
-
-        return clone;
       },
     };
   },

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -1,3 +1,8 @@
+import {
+  isInSkipSet,
+  parseSkippedExamples,
+  toSkipSet,
+} from '../isomorphic/parseSkippedExamples.ts';
 import type { NextExampleResult, WindowWithHappo } from '../isomorphic/types.ts';
 
 interface HappoStaticExample extends NextExampleResult {
@@ -42,7 +47,13 @@ const happoStatic = {
       },
 
       nextExample: async () => {
-        const happoSkipped = (globalThis as { happoSkipped?: Array<{ component: string; variant: string }> }).happoSkipped;
+        const happoSkippedEl =
+          typeof document !== 'undefined'
+            ? document.getElementById('happo-skipped')
+            : null;
+        const skipSet = toSkipSet(
+          parseSkippedExamples(happoSkippedEl?.textContent ?? undefined),
+        );
 
         while (true) {
           const example = examples[currentIndex];
@@ -52,14 +63,7 @@ const happoStatic = {
             return;
           }
 
-          if (
-            Array.isArray(happoSkipped) &&
-            happoSkipped.some(
-              (item) =>
-                item.component === example.component &&
-                (item.variant === undefined || item.variant === example.variant),
-            )
-          ) {
+          if (isInSkipSet(skipSet, example.component, example.variant)) {
             currentIndex++;
             continue;
           }

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -56,7 +56,8 @@ const happoStatic = {
             Array.isArray(happoSkipped) &&
             happoSkipped.some(
               (item) =>
-                item.component === example.component && item.variant === example.variant,
+                item.component === example.component &&
+                (item.variant === undefined || item.variant === example.variant),
             )
           ) {
             currentIndex++;

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -48,9 +48,9 @@ const happoStatic = {
 
       nextExample: async () => {
         const happoSkippedEl =
-          typeof document !== 'undefined'
-            ? document.getElementById('happo-skipped')
-            : null;
+          typeof document === 'undefined'
+            ? null
+            : document.getElementById('happo-skipped');
         const skipSet = toSkipSet(
           parseSkippedExamples(happoSkippedEl?.textContent ?? undefined),
         );

--- a/src/cypress/index.ts
+++ b/src/cypress/index.ts
@@ -105,6 +105,7 @@ let config: CypressConfig = {
 
 // Cached so the happoGetIntegrationConfig task is called at most once per run.
 let cachedAutoApplyPseudoStateAttributes: boolean | null = null;
+let cachedSkippedExamples: Array<{ component: string; variant: string }> | null = null;
 
 export const configure = (userConfig?: Partial<CypressConfig>): void => {
   config = { ...config, ...userConfig };
@@ -201,16 +202,23 @@ Cypress.Commands.add(
     };
 
     if (cachedAutoApplyPseudoStateAttributes === null) {
-      cy.task<{ autoApplyPseudoStateAttributes: boolean } | null>(
+      cy.task<{ autoApplyPseudoStateAttributes: boolean; skippedExamples: Array<{ component: string; variant: string }> } | null>(
         'happoGetIntegrationConfig',
         null,
         { ...taskOptions, log: false },
-      ).then((integrationConfig) => {
+      ).then((happoSettings) => {
         cachedAutoApplyPseudoStateAttributes =
-          integrationConfig?.autoApplyPseudoStateAttributes ?? false;
+          happoSettings?.autoApplyPseudoStateAttributes ?? false;
+        cachedSkippedExamples = happoSettings?.skippedExamples ?? [];
+        if (cachedSkippedExamples.some((item) => item.component === component && item.variant === variant)) {
+          return;
+        }
         takeSnapshot(cachedAutoApplyPseudoStateAttributes);
       });
     } else {
+      if (cachedSkippedExamples?.some((item) => item.component === component && item.variant === variant)) {
+        return;
+      }
       takeSnapshot(cachedAutoApplyPseudoStateAttributes);
     }
   },

--- a/src/cypress/index.ts
+++ b/src/cypress/index.ts
@@ -210,13 +210,13 @@ Cypress.Commands.add(
         cachedAutoApplyPseudoStateAttributes =
           happoSettings?.autoApplyPseudoStateAttributes ?? false;
         cachedSkippedExamples = happoSettings?.skippedExamples ?? [];
-        if (cachedSkippedExamples.some((item) => item.component === component && item.variant === variant)) {
+        if (cachedSkippedExamples.some((item) => item.component === component && (item.variant === undefined || item.variant === variant))) {
           return;
         }
         takeSnapshot(cachedAutoApplyPseudoStateAttributes);
       });
     } else {
-      if (cachedSkippedExamples?.some((item) => item.component === component && item.variant === variant)) {
+      if (cachedSkippedExamples?.some((item) => item.component === component && (item.variant === undefined || item.variant === variant))) {
         return;
       }
       takeSnapshot(cachedAutoApplyPseudoStateAttributes);

--- a/src/cypress/index.ts
+++ b/src/cypress/index.ts
@@ -6,7 +6,7 @@ import {
   isInSkipSet,
   type SkipSet,
   toSkipSet,
-} from '../isomorphic/parseSkippedExamples.ts';
+} from '../isomorphic/parseSkip.ts';
 import type { TakeDOMSnapshotOptions } from '../isomorphic/types.ts';
 import chunked from './chunked.ts';
 
@@ -207,14 +207,14 @@ Cypress.Commands.add(
     };
 
     if (cachedAutoApplyPseudoStateAttributes === null) {
-      cy.task<{ autoApplyPseudoStateAttributes: boolean; skippedExamples: Array<{ component: string; variant?: string }> } | null>(
+      cy.task<{ autoApplyPseudoStateAttributes: boolean; skip: Array<{ component: string; variant?: string }> } | null>(
         'happoGetIntegrationConfig',
         null,
         { ...taskOptions, log: false },
       ).then((happoSettings) => {
         cachedAutoApplyPseudoStateAttributes =
           happoSettings?.autoApplyPseudoStateAttributes ?? false;
-        cachedSkipSet = toSkipSet(happoSettings?.skippedExamples ?? []);
+        cachedSkipSet = toSkipSet(happoSettings?.skip ?? []);
         if (isInSkipSet(cachedSkipSet, component, variant)) {
           return;
         }

--- a/src/cypress/index.ts
+++ b/src/cypress/index.ts
@@ -2,6 +2,11 @@ import applyConstructedStylesPatch, {
   isExtendedWindow,
 } from '../browser/applyConstructedStylesPatch.ts';
 import takeDOMSnapshot from '../browser/takeDOMSnapshot.ts';
+import {
+  isInSkipSet,
+  type SkipSet,
+  toSkipSet,
+} from '../isomorphic/parseSkippedExamples.ts';
 import type { TakeDOMSnapshotOptions } from '../isomorphic/types.ts';
 import chunked from './chunked.ts';
 
@@ -105,7 +110,7 @@ let config: CypressConfig = {
 
 // Cached so the happoGetIntegrationConfig task is called at most once per run.
 let cachedAutoApplyPseudoStateAttributes: boolean | null = null;
-let cachedSkippedExamples: Array<{ component: string; variant: string }> | null = null;
+let cachedSkipSet: SkipSet | null = null;
 
 export const configure = (userConfig?: Partial<CypressConfig>): void => {
   config = { ...config, ...userConfig };
@@ -202,21 +207,21 @@ Cypress.Commands.add(
     };
 
     if (cachedAutoApplyPseudoStateAttributes === null) {
-      cy.task<{ autoApplyPseudoStateAttributes: boolean; skippedExamples: Array<{ component: string; variant: string }> } | null>(
+      cy.task<{ autoApplyPseudoStateAttributes: boolean; skippedExamples: Array<{ component: string; variant?: string }> } | null>(
         'happoGetIntegrationConfig',
         null,
         { ...taskOptions, log: false },
       ).then((happoSettings) => {
         cachedAutoApplyPseudoStateAttributes =
           happoSettings?.autoApplyPseudoStateAttributes ?? false;
-        cachedSkippedExamples = happoSettings?.skippedExamples ?? [];
-        if (cachedSkippedExamples.some((item) => item.component === component && (item.variant === undefined || item.variant === variant))) {
+        cachedSkipSet = toSkipSet(happoSettings?.skippedExamples ?? []);
+        if (isInSkipSet(cachedSkipSet, component, variant)) {
           return;
         }
         takeSnapshot(cachedAutoApplyPseudoStateAttributes);
       });
     } else {
-      if (cachedSkippedExamples?.some((item) => item.component === component && (item.variant === undefined || item.variant === variant))) {
+      if (cachedSkipSet && isInSkipSet(cachedSkipSet, component, variant)) {
         return;
       }
       takeSnapshot(cachedAutoApplyPseudoStateAttributes);

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 
 import Controller, { type SnapshotRegistrationParams } from '../e2e/controller.ts';
-import { parseSkippedExamples } from '../isomorphic/parseSkippedExamples.ts';
+import { parseSkip } from '../isomorphic/parseSkip.ts';
 
 const controller = new Controller();
 let disabledLogged = false;
@@ -44,7 +44,7 @@ function getCleanupTimeframe({
 
 interface HappoScreenshotConfig {
   autoApplyPseudoStateAttributes: boolean;
-  skippedExamples: Array<{ component: string; variant?: string }>;
+  skip: Array<{ component: string; variant?: string }>;
 }
 
 interface HappoTask {
@@ -146,21 +146,21 @@ const task: HappoTask = {
   happoGetIntegrationConfig(): HappoScreenshotConfig {
     const integration = controller.config?.integration;
     let rawSkipped: string | undefined;
-    const skippedFilePath = process.env.HAPPO_SKIPPED_EXAMPLES_FILE;
+    const skippedFilePath = process.env.HAPPO_SKIP_FILE;
     if (skippedFilePath) {
       try {
         rawSkipped = fs.readFileSync(skippedFilePath, 'utf8');
       } catch (e) {
-        console.warn('[HAPPO] Failed to read HAPPO_SKIPPED_EXAMPLES_FILE:', e);
+        console.warn('[HAPPO] Failed to read HAPPO_SKIP_FILE:', e);
       }
     }
-    const skippedExamples = parseSkippedExamples(rawSkipped);
+    const skip = parseSkip(rawSkipped);
     return {
       autoApplyPseudoStateAttributes:
         integration?.type === 'cypress'
           ? (integration.autoApplyPseudoStateAttributes ?? false)
           : false,
-      skippedExamples,
+      skip,
     };
   },
 

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -143,7 +143,18 @@ const task: HappoTask = {
 
   happoGetIntegrationConfig(): HappoScreenshotConfig {
     const integration = controller.config?.integration;
-    const skippedExamples = parseSkippedExamples(process.env.HAPPO_SKIPPED_EXAMPLES);
+    const rawSkipped = process.env.HAPPO_SKIPPED_EXAMPLES;
+    if (rawSkipped) {
+      try {
+        const p: unknown = JSON.parse(rawSkipped);
+        if (!Array.isArray(p)) {
+          console.warn('[HAPPO] HAPPO_SKIPPED_EXAMPLES is not a JSON array, will be ignored:', rawSkipped);
+        }
+      } catch {
+        console.warn('[HAPPO] HAPPO_SKIPPED_EXAMPLES is not valid JSON, will be ignored:', rawSkipped);
+      }
+    }
+    const skippedExamples = parseSkippedExamples(rawSkipped);
     return {
       autoApplyPseudoStateAttributes:
         integration?.type === 'cypress'

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+
 import Controller, { type SnapshotRegistrationParams } from '../e2e/controller.ts';
 import { parseSkippedExamples } from '../isomorphic/parseSkippedExamples.ts';
 
@@ -143,15 +145,13 @@ const task: HappoTask = {
 
   happoGetIntegrationConfig(): HappoScreenshotConfig {
     const integration = controller.config?.integration;
-    const rawSkipped = process.env.HAPPO_SKIPPED_EXAMPLES;
-    if (rawSkipped) {
+    let rawSkipped: string | undefined;
+    const skippedFilePath = process.env.HAPPO_SKIPPED_EXAMPLES_FILE;
+    if (skippedFilePath) {
       try {
-        const p: unknown = JSON.parse(rawSkipped);
-        if (!Array.isArray(p)) {
-          console.warn('[HAPPO] HAPPO_SKIPPED_EXAMPLES is not a JSON array, will be ignored:', rawSkipped);
-        }
-      } catch {
-        console.warn('[HAPPO] HAPPO_SKIPPED_EXAMPLES is not valid JSON, will be ignored:', rawSkipped);
+        rawSkipped = fs.readFileSync(skippedFilePath, 'utf8');
+      } catch (e) {
+        console.warn('[HAPPO] Failed to read HAPPO_SKIPPED_EXAMPLES_FILE:', e);
       }
     }
     const skippedExamples = parseSkippedExamples(rawSkipped);

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -145,7 +145,19 @@ const task: HappoTask = {
     let skippedExamples: Array<{ component: string; variant: string }> = [];
     if (process.env.HAPPO_SKIPPED_EXAMPLES) {
       try {
-        skippedExamples = JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES) as typeof skippedExamples;
+        const parsed: unknown = JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES);
+        if (
+          Array.isArray(parsed) &&
+          parsed.every(
+            (item): item is { component: string; variant: string } =>
+              typeof item === 'object' &&
+              item !== null &&
+              typeof item.component === 'string' &&
+              typeof item.variant === 'string',
+          )
+        ) {
+          skippedExamples = parsed;
+        }
       } catch {
         // ignore parse errors
       }

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -39,8 +39,9 @@ function getCleanupTimeframe({
   return { start, end };
 }
 
-interface IntegrationConfig {
+interface HappoScreenshotConfig {
   autoApplyPseudoStateAttributes: boolean;
+  skippedExamples: Array<{ component: string; variant: string }>;
 }
 
 interface HappoTask {
@@ -57,7 +58,7 @@ interface HappoTask {
     isFirst: boolean;
     isLast: boolean;
   }): Promise<null>;
-  happoGetIntegrationConfig(): IntegrationConfig;
+  happoGetHappoScreenshotConfig(): HappoScreenshotConfig;
   handleBeforeSpec(): Promise<void>;
 }
 
@@ -68,7 +69,7 @@ const task: HappoTask = {
     on('task', {
       happoRegisterSnapshot: task.happoRegisterSnapshot,
       happoRegisterBase64Image: task.happoRegisterBase64Image,
-      happoGetIntegrationConfig: task.happoGetIntegrationConfig,
+      happoGetHappoScreenshotConfig: task.happoGetHappoScreenshotConfig,
     });
     on('before:spec', task.handleBeforeSpec);
     on('after:spec', task.handleAfterSpec);
@@ -139,13 +140,22 @@ const task: HappoTask = {
     return null;
   },
 
-  happoGetIntegrationConfig(): IntegrationConfig {
+  happoGetHappoScreenshotConfig(): HappoScreenshotConfig {
     const integration = controller.config?.integration;
+    let skippedExamples: Array<{ component: string; variant: string }> = [];
+    if (process.env.HAPPO_SKIPPED_EXAMPLES) {
+      try {
+        skippedExamples = JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES) as typeof skippedExamples;
+      } catch {
+        // ignore parse errors
+      }
+    }
     return {
       autoApplyPseudoStateAttributes:
         integration?.type === 'cypress'
           ? (integration.autoApplyPseudoStateAttributes ?? false)
           : false,
+      skippedExamples,
     };
   },
 

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -1,4 +1,5 @@
 import Controller, { type SnapshotRegistrationParams } from '../e2e/controller.ts';
+import { parseSkippedExamples } from '../isomorphic/parseSkippedExamples.ts';
 
 const controller = new Controller();
 let disabledLogged = false;
@@ -142,27 +143,7 @@ const task: HappoTask = {
 
   happoGetIntegrationConfig(): HappoScreenshotConfig {
     const integration = controller.config?.integration;
-    let skippedExamples: Array<{ component: string; variant?: string }> = [];
-    if (process.env.HAPPO_SKIPPED_EXAMPLES) {
-      try {
-        const parsed: unknown = JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES);
-        if (
-          Array.isArray(parsed) &&
-          parsed.every(
-            (item): item is { component: string; variant?: string } =>
-              typeof item === 'object' &&
-              item !== null &&
-              typeof (item as Record<string, unknown>).component === 'string' &&
-              ((item as Record<string, unknown>).variant === undefined ||
-                typeof (item as Record<string, unknown>).variant === 'string'),
-          )
-        ) {
-          skippedExamples = parsed;
-        }
-      } catch {
-        // ignore parse errors
-      }
-    }
+    const skippedExamples = parseSkippedExamples(process.env.HAPPO_SKIPPED_EXAMPLES);
     return {
       autoApplyPseudoStateAttributes:
         integration?.type === 'cypress'

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -41,7 +41,7 @@ function getCleanupTimeframe({
 
 interface HappoScreenshotConfig {
   autoApplyPseudoStateAttributes: boolean;
-  skippedExamples: Array<{ component: string; variant: string }>;
+  skippedExamples: Array<{ component: string; variant?: string }>;
 }
 
 interface HappoTask {
@@ -142,18 +142,19 @@ const task: HappoTask = {
 
   happoGetIntegrationConfig(): HappoScreenshotConfig {
     const integration = controller.config?.integration;
-    let skippedExamples: Array<{ component: string; variant: string }> = [];
+    let skippedExamples: Array<{ component: string; variant?: string }> = [];
     if (process.env.HAPPO_SKIPPED_EXAMPLES) {
       try {
         const parsed: unknown = JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES);
         if (
           Array.isArray(parsed) &&
           parsed.every(
-            (item): item is { component: string; variant: string } =>
+            (item): item is { component: string; variant?: string } =>
               typeof item === 'object' &&
               item !== null &&
-              typeof item.component === 'string' &&
-              typeof item.variant === 'string',
+              typeof (item as Record<string, unknown>).component === 'string' &&
+              ((item as Record<string, unknown>).variant === undefined ||
+                typeof (item as Record<string, unknown>).variant === 'string'),
           )
         ) {
           skippedExamples = parsed;

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -58,7 +58,7 @@ interface HappoTask {
     isFirst: boolean;
     isLast: boolean;
   }): Promise<null>;
-  happoGetHappoScreenshotConfig(): HappoScreenshotConfig;
+  happoGetIntegrationConfig(): HappoScreenshotConfig;
   handleBeforeSpec(): Promise<void>;
 }
 
@@ -69,7 +69,7 @@ const task: HappoTask = {
     on('task', {
       happoRegisterSnapshot: task.happoRegisterSnapshot,
       happoRegisterBase64Image: task.happoRegisterBase64Image,
-      happoGetHappoScreenshotConfig: task.happoGetHappoScreenshotConfig,
+      happoGetIntegrationConfig: task.happoGetIntegrationConfig,
     });
     on('before:spec', task.handleBeforeSpec);
     on('after:spec', task.handleAfterSpec);
@@ -140,7 +140,7 @@ const task: HappoTask = {
     return null;
   },
 
-  happoGetHappoScreenshotConfig(): HappoScreenshotConfig {
+  happoGetIntegrationConfig(): HappoScreenshotConfig {
     const integration = controller.config?.integration;
     let skippedExamples: Array<{ component: string; variant: string }> = [];
     if (process.env.HAPPO_SKIPPED_EXAMPLES) {

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -57,7 +57,7 @@ export async function finalizeAll({
   environment,
   logger,
 }: FinalizeAllOptions): Promise<void> {
-  const { afterSha, nonce, skippedExamples: skippedExamplesJSON } = environment;
+  const { afterSha, nonce, skip: skipJSON } = environment;
 
   if (!nonce) {
     throw new Error('[HAPPO] Missing --nonce argument');
@@ -66,19 +66,19 @@ export async function finalizeAll({
   const body: {
     project?: string | undefined;
     nonce: string;
-    skippedExamples: Array<Example>;
+    skip: Array<Example>;
   } = {
     project: happoConfig.project,
     nonce,
-    skippedExamples: [],
+    skip: [],
   };
 
-  if (skippedExamplesJSON) {
+  if (skipJSON) {
     try {
-      const skippedExamples = JSON.parse(skippedExamplesJSON);
-      body.skippedExamples = skippedExamples;
+      const skipItems = JSON.parse(skipJSON);
+      body.skip = skipItems;
     } catch (e) {
-      logger.error('Error when parsing --skippedExamples', skippedExamplesJSON);
+      logger.error('Error when parsing --skip', skipJSON);
       throw e;
     }
   }
@@ -228,7 +228,7 @@ export default async function runWithWrapper(
   environment: EnvironmentResult,
   logger: Logger,
   configFilePath: string,
-  skippedExamplesJSON?: string,
+  skipJSON?: string,
 ): Promise<number> {
   allRequestIds = new Set<number>();
   const e2eServer = await startE2EServer(environment, happoConfig);
@@ -240,13 +240,13 @@ export default async function runWithWrapper(
   }
 
   // Write skipped examples to a temp file to avoid env var size limits.
-  let skippedExamplesFilePath: string | undefined;
-  if (skippedExamplesJSON) {
-    skippedExamplesFilePath = path.join(
+  let skipFilePath: string | undefined;
+  if (skipJSON) {
+    skipFilePath = path.join(
       os.tmpdir(),
       `happo-skipped-${process.pid}.json`,
     );
-    await fs.promises.writeFile(skippedExamplesFilePath, skippedExamplesJSON, 'utf8');
+    await fs.promises.writeFile(skipFilePath, skipJSON, 'utf8');
   }
 
   try {
@@ -259,8 +259,8 @@ export default async function runWithWrapper(
         HAPPO_API_SECRET: happoConfig.apiSecret,
       };
 
-      if (skippedExamplesFilePath) {
-        childEnv.HAPPO_SKIPPED_EXAMPLES_FILE = skippedExamplesFilePath;
+      if (skipFilePath) {
+        childEnv.HAPPO_SKIP_FILE = skipFilePath;
       }
 
       const child = spawn(dashdashCommandParts[0]!, dashdashCommandParts.slice(1), {
@@ -307,8 +307,8 @@ export default async function runWithWrapper(
   } finally {
     allRequestIds.clear();
     await e2eServer.close();
-    if (skippedExamplesFilePath) {
-      await fs.promises.unlink(skippedExamplesFilePath).catch(() => {
+    if (skipFilePath) {
+      await fs.promises.unlink(skipFilePath).catch(() => {
         // Ignore errors — the file may already be gone.
       });
     }

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -225,6 +225,7 @@ export default async function runWithWrapper(
   environment: EnvironmentResult,
   logger: Logger,
   configFilePath: string,
+  skippedExamplesJSON?: string,
 ): Promise<number> {
   allRequestIds = new Set<number>();
   const e2eServer = await startE2EServer(environment, happoConfig);
@@ -236,15 +237,21 @@ export default async function runWithWrapper(
   }
   try {
     const exitCode = await new Promise<number>((resolve, reject) => {
+      const childEnv: Record<string, string | undefined> = {
+        ...process.env,
+        HAPPO_E2E_PORT: e2eServer.port.toString(),
+        HAPPO_CONFIG_FILE: configFilePath,
+        HAPPO_API_KEY: happoConfig.apiKey,
+        HAPPO_API_SECRET: happoConfig.apiSecret,
+      };
+
+      if (skippedExamplesJSON) {
+        childEnv.HAPPO_SKIPPED_EXAMPLES = skippedExamplesJSON;
+      }
+
       const child = spawn(dashdashCommandParts[0]!, dashdashCommandParts.slice(1), {
         stdio: 'inherit',
-        env: {
-          ...process.env,
-          HAPPO_E2E_PORT: e2eServer.port.toString(),
-          HAPPO_CONFIG_FILE: configFilePath,
-          HAPPO_API_KEY: happoConfig.apiKey,
-          HAPPO_API_SECRET: happoConfig.apiSecret,
-        },
+        env: childEnv,
         shell: process.platform == 'win32',
       });
 

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -1,5 +1,8 @@
 import { spawn } from 'node:child_process';
+import fs from 'node:fs';
 import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
 
 import type { ConfigWithDefaults, E2EIntegration } from '../config/index.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
@@ -235,6 +238,17 @@ export default async function runWithWrapper(
   if (!job) {
     throw new Error('Failed to create Happo job');
   }
+
+  // Write skipped examples to a temp file to avoid env var size limits.
+  let skippedExamplesFilePath: string | undefined;
+  if (skippedExamplesJSON) {
+    skippedExamplesFilePath = path.join(
+      os.tmpdir(),
+      `happo-skipped-${process.pid}.json`,
+    );
+    await fs.promises.writeFile(skippedExamplesFilePath, skippedExamplesJSON, 'utf8');
+  }
+
   try {
     const exitCode = await new Promise<number>((resolve, reject) => {
       const childEnv: Record<string, string | undefined> = {
@@ -245,8 +259,8 @@ export default async function runWithWrapper(
         HAPPO_API_SECRET: happoConfig.apiSecret,
       };
 
-      if (skippedExamplesJSON) {
-        childEnv.HAPPO_SKIPPED_EXAMPLES = skippedExamplesJSON;
+      if (skippedExamplesFilePath) {
+        childEnv.HAPPO_SKIPPED_EXAMPLES_FILE = skippedExamplesFilePath;
       }
 
       const child = spawn(dashdashCommandParts[0]!, dashdashCommandParts.slice(1), {
@@ -293,5 +307,10 @@ export default async function runWithWrapper(
   } finally {
     allRequestIds.clear();
     await e2eServer.close();
+    if (skippedExamplesFilePath) {
+      await fs.promises.unlink(skippedExamplesFilePath).catch(() => {
+        // Ignore errors — the file may already be gone.
+      });
+    }
   }
 }

--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -627,17 +627,17 @@ describe('resolveEnvironment', () => {
     assert.ok(result.message !== undefined);
   });
 
-  it('passes skippedExamples from CLI args into the environment result', async () => {
+  it('passes skip from CLI args into the environment result', async () => {
     initGitRepo();
-    const skippedExamples = '[{"component":"Button","variant":"primary","target":"chrome"}]';
-    const result = await resolveEnvironment({ skippedExamples }, {});
-    assert.equal(result.skippedExamples, skippedExamples);
+    const skip = '[{"component":"Button","variant":"primary","target":"chrome"}]';
+    const result = await resolveEnvironment({ skip }, {});
+    assert.equal(result.skip, skip);
   });
 
-  it('sets skippedExamples to undefined when not provided', async () => {
+  it('sets skip to undefined when not provided', async () => {
     initGitRepo();
     const result = await resolveEnvironment({}, {});
-    assert.equal(result.skippedExamples, undefined);
+    assert.equal(result.skip, undefined);
   });
 
   it('rejects if the link is not a valid URL', async () => {

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -44,7 +44,7 @@ export interface EnvironmentResult {
   fallbackShas: Array<string> | undefined;
   githubToken: string | undefined;
   ci: boolean;
-  skippedExamples: string | undefined;
+  skip: string | undefined;
 }
 
 const envKeys: ReadonlyArray<string> = [
@@ -640,7 +640,7 @@ export default async function resolveEnvironment(
     fallbackShas: resolveFallbackShas(cliArgs, nonNullBeforeSha),
     githubToken: cliArgs.githubToken,
     ci: !!env.CI,
-    skippedExamples: cliArgs.skippedExamples,
+    skip: cliArgs.skip,
   };
 
   if (debugMode) {

--- a/src/isomorphic/parseSkip.ts
+++ b/src/isomorphic/parseSkip.ts
@@ -20,11 +20,11 @@ function isSkipItem(item: unknown): item is SkipItem {
  * Parses and validates a JSON string, returning an array of SkipItems.
  * Throws a TypeError if the JSON is invalid or not an array of SkipItems.
  */
-export function validateSkippedExamples(json: string): Array<SkipItem> {
+export function validateSkip(json: string): Array<SkipItem> {
   const parsed: unknown = JSON.parse(json);
   if (!Array.isArray(parsed) || !parsed.every(isSkipItem)) {
     throw new TypeError(
-      '--skippedExamples must be a JSON array of {component, variant?} objects',
+      '--skip must be a JSON array of {component, variant?} objects',
     );
   }
   return parsed;
@@ -34,10 +34,10 @@ export function validateSkippedExamples(json: string): Array<SkipItem> {
  * Parses a JSON string into an array of SkipItems. Returns an empty array on
  * any parse error or if the value is not a valid array of SkipItems.
  */
-export function parseSkippedExamples(json: string | undefined): Array<SkipItem> {
+export function parseSkip(json: string | undefined): Array<SkipItem> {
   if (!json) return [];
   try {
-    return validateSkippedExamples(json);
+    return validateSkip(json);
   } catch {
     return [];
   }

--- a/src/isomorphic/parseSkippedExamples.ts
+++ b/src/isomorphic/parseSkippedExamples.ts
@@ -1,0 +1,63 @@
+import type { SkipItem } from './types.ts';
+
+/**
+ * A pair of Sets used for O(1) skip lookups.
+ * - [0]: component-only skips (match all variants of the component)
+ * - [1]: component+variant skips (match a specific variant, keyed as "component\0variant")
+ */
+export type SkipSet = readonly [componentOnly: Set<string>, componentVariant: Set<string>];
+
+/**
+ * Parses a JSON string into an array of SkipItems. Returns an empty array on
+ * any parse error or if the value is not a valid array of SkipItems.
+ */
+export function parseSkippedExamples(json: string | undefined): Array<SkipItem> {
+  if (!json) return [];
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (
+      Array.isArray(parsed) &&
+      parsed.every(
+        (item): item is SkipItem =>
+          typeof item === 'object' &&
+          item !== null &&
+          typeof (item as Record<string, unknown>).component === 'string' &&
+          ((item as Record<string, unknown>).variant === undefined ||
+            typeof (item as Record<string, unknown>).variant === 'string'),
+      )
+    ) {
+      return parsed;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return [];
+}
+
+/**
+ * Converts an array of SkipItems into a SkipSet for efficient lookups.
+ */
+export function toSkipSet(items: Array<SkipItem>): SkipSet {
+  const componentOnly = new Set<string>();
+  const componentVariant = new Set<string>();
+  for (const { component, variant } of items) {
+    if (variant === undefined) {
+      componentOnly.add(component);
+    } else {
+      componentVariant.add(`${component}\0${variant}`);
+    }
+  }
+  return [componentOnly, componentVariant];
+}
+
+/**
+ * Returns true if the given component+variant should be skipped according to
+ * the SkipSet.
+ */
+export function isInSkipSet(
+  [componentOnly, componentVariant]: SkipSet,
+  component: string,
+  variant: string,
+): boolean {
+  return componentOnly.has(component) || componentVariant.has(`${component}\0${variant}`);
+}

--- a/src/isomorphic/parseSkippedExamples.ts
+++ b/src/isomorphic/parseSkippedExamples.ts
@@ -7,6 +7,29 @@ import type { SkipItem } from './types.ts';
  */
 export type SkipSet = readonly [componentOnly: Set<string>, componentVariant: Set<string>];
 
+function isSkipItem(item: unknown): item is SkipItem {
+  if (typeof item !== 'object' || item === null) return false;
+  const record = item as Record<string, unknown>;
+  return (
+    typeof record['component'] === 'string' &&
+    (record['variant'] === undefined || typeof record['variant'] === 'string')
+  );
+}
+
+/**
+ * Parses and validates a JSON string, returning an array of SkipItems.
+ * Throws a TypeError if the JSON is invalid or not an array of SkipItems.
+ */
+export function validateSkippedExamples(json: string): Array<SkipItem> {
+  const parsed: unknown = JSON.parse(json);
+  if (!Array.isArray(parsed) || !parsed.every(isSkipItem)) {
+    throw new TypeError(
+      '--skippedExamples must be a JSON array of {component, variant?} objects',
+    );
+  }
+  return parsed;
+}
+
 /**
  * Parses a JSON string into an array of SkipItems. Returns an empty array on
  * any parse error or if the value is not a valid array of SkipItems.
@@ -14,24 +37,10 @@ export type SkipSet = readonly [componentOnly: Set<string>, componentVariant: Se
 export function parseSkippedExamples(json: string | undefined): Array<SkipItem> {
   if (!json) return [];
   try {
-    const parsed: unknown = JSON.parse(json);
-    if (
-      Array.isArray(parsed) &&
-      parsed.every(
-        (item): item is SkipItem =>
-          typeof item === 'object' &&
-          item !== null &&
-          typeof (item as Record<string, unknown>).component === 'string' &&
-          ((item as Record<string, unknown>).variant === undefined ||
-            typeof (item as Record<string, unknown>).variant === 'string'),
-      )
-    ) {
-      return parsed;
-    }
+    return validateSkippedExamples(json);
   } catch {
-    // ignore parse errors
+    return [];
   }
-  return [];
 }
 
 /**

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -81,5 +81,5 @@ export type Logger = Pick<Console, 'log' | 'error'>;
 
 export interface SkipItem {
   component: string;
-  variant: string;
+  variant?: string;
 }

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -78,3 +78,8 @@ export interface WindowWithHappo extends Window {
 }
 
 export type Logger = Pick<Console, 'log' | 'error'>;
+
+export interface SkipItem {
+  component: string;
+  variant: string;
+}

--- a/src/network/__tests__/cancelJob.test.ts
+++ b/src/network/__tests__/cancelJob.test.ts
@@ -61,7 +61,7 @@ beforeEach(async () => {
     fallbackShas: ['test-sha'],
     githubToken: 'test-token',
     ci: false,
-    skippedExamples: undefined,
+    skip: undefined,
   };
 
   makeHappoAPIRequestImpl = async () => {

--- a/src/network/__tests__/createAsyncComparison.test.ts
+++ b/src/network/__tests__/createAsyncComparison.test.ts
@@ -69,7 +69,7 @@ beforeEach(async () => {
     nonce: undefined,
     githubToken: undefined,
     debugMode: false,
-    skippedExamples: undefined,
+    skip: undefined,
   };
 
   makeHappoAPIRequestMock.mock.resetCalls();

--- a/src/network/__tests__/createExtendsReportSnapRequest.test.ts
+++ b/src/network/__tests__/createExtendsReportSnapRequest.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert';
+import type { Mock } from 'node:test';
+import { beforeEach, describe, it, mock } from 'node:test';
+
+import type { ConfigWithDefaults } from '../../config/index.ts';
+import type { SkipItem } from '../../isomorphic/types.ts';
+import type makeHappoAPIRequest from '../makeHappoAPIRequest.ts';
+
+type MakeHappoAPIRequestImpl = (...args: Array<unknown>) => Promise<object | null>;
+
+let makeHappoAPIRequestImpl: MakeHappoAPIRequestImpl;
+const makeHappoAPIRequestMock: Mock<typeof makeHappoAPIRequest> = mock.fn(
+  async (...args: Array<unknown>) => {
+    return await makeHappoAPIRequestImpl(...args);
+  },
+);
+
+mock.module('../makeHappoAPIRequest.ts', {
+  defaultExport: makeHappoAPIRequestMock,
+});
+
+let config: ConfigWithDefaults;
+let createExtendsReportSnapRequest: typeof import('../createExtendsReportSnapRequest.ts').default;
+
+const skippedExamples: Array<SkipItem> = [
+  { component: 'Button', variant: 'Primary' },
+  { component: 'Button', variant: 'Secondary' },
+];
+
+beforeEach(async () => {
+  config = {
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+    endpoint: 'https://happo.io',
+    githubApiUrl: 'https://api.github.com',
+    project: 'test-project',
+    targets: {},
+    integration: { type: 'storybook' },
+  };
+
+  makeHappoAPIRequestImpl = async () => ({ requestId: 42 });
+
+  ({ default: createExtendsReportSnapRequest } = await import(
+    '../createExtendsReportSnapRequest.ts'
+  ));
+  makeHappoAPIRequestMock.mock.resetCalls();
+});
+
+describe('createExtendsReportSnapRequest', () => {
+  it('posts to the extends-report endpoint', async () => {
+    await createExtendsReportSnapRequest('baseline-sha', skippedExamples, config);
+
+    assert.strictEqual(makeHappoAPIRequestMock.mock.callCount(), 1);
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+    assert.strictEqual(call.arguments[0]?.path, '/api/snap-requests/extends-report');
+    assert.strictEqual(call.arguments[0]?.method, 'POST');
+  });
+
+  it('sends extendedSnaps, extendsSha, and project in the request body', async () => {
+    await createExtendsReportSnapRequest('baseline-sha', skippedExamples, config);
+
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+    const body = call.arguments[0]?.body as {
+      extendedSnaps?: Array<SkipItem>;
+      extendsSha?: string;
+      project?: string;
+    };
+    assert.ok(body);
+    assert.deepStrictEqual(body.extendedSnaps, skippedExamples);
+    assert.strictEqual(body.extendsSha, 'baseline-sha');
+    assert.strictEqual(body.project, 'test-project');
+  });
+
+  it('returns the requestId from the response', async () => {
+    const result = await createExtendsReportSnapRequest(
+      'baseline-sha',
+      skippedExamples,
+      config,
+    );
+
+    assert.strictEqual(result, 42);
+  });
+
+  it('works with an empty skipped examples array', async () => {
+    await createExtendsReportSnapRequest('baseline-sha', [], config);
+
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+    const body = call.arguments[0]?.body as { extendedSnaps?: Array<SkipItem> };
+    assert.ok(body);
+    assert.deepStrictEqual(body.extendedSnaps, []);
+  });
+
+  it('throws when the response has no requestId', async () => {
+    makeHappoAPIRequestImpl = async () => ({ status: 'ok' });
+
+    await assert.rejects(
+      () => createExtendsReportSnapRequest('baseline-sha', skippedExamples, config),
+      /Invalid response from extends-report snap request API/,
+    );
+  });
+
+  it('throws when requestId is not a number', async () => {
+    makeHappoAPIRequestImpl = async () => ({ requestId: 'not-a-number' });
+
+    await assert.rejects(
+      () => createExtendsReportSnapRequest('baseline-sha', skippedExamples, config),
+      /Invalid response from extends-report snap request API/,
+    );
+  });
+
+  it('throws when the API request itself throws', async () => {
+    makeHappoAPIRequestImpl = async () => {
+      throw new Error('network failure');
+    };
+
+    await assert.rejects(
+      () => createExtendsReportSnapRequest('baseline-sha', skippedExamples, config),
+      /network failure/,
+    );
+  });
+});

--- a/src/network/__tests__/createExtendsReportSnapRequest.test.ts
+++ b/src/network/__tests__/createExtendsReportSnapRequest.test.ts
@@ -22,7 +22,7 @@ mock.module('../makeHappoAPIRequest.ts', {
 let config: ConfigWithDefaults;
 let createExtendsReportSnapRequest: typeof import('../createExtendsReportSnapRequest.ts').default;
 
-const skippedExamples: Array<SkipItem> = [
+const skip: Array<SkipItem> = [
   { component: 'Button', variant: 'Primary' },
   { component: 'Button', variant: 'Secondary' },
 ];
@@ -48,7 +48,7 @@ beforeEach(async () => {
 
 describe('createExtendsReportSnapRequest', () => {
   it('posts to the extends-report endpoint', async () => {
-    await createExtendsReportSnapRequest('baseline-sha', skippedExamples, config);
+    await createExtendsReportSnapRequest('baseline-sha', skip, config);
 
     assert.strictEqual(makeHappoAPIRequestMock.mock.callCount(), 1);
     const call = makeHappoAPIRequestMock.mock.calls[0];
@@ -58,7 +58,7 @@ describe('createExtendsReportSnapRequest', () => {
   });
 
   it('sends extendedSnaps, extendsSha, and project in the request body', async () => {
-    await createExtendsReportSnapRequest('baseline-sha', skippedExamples, config);
+    await createExtendsReportSnapRequest('baseline-sha', skip, config);
 
     const call = makeHappoAPIRequestMock.mock.calls[0];
     assert.ok(call);
@@ -68,7 +68,7 @@ describe('createExtendsReportSnapRequest', () => {
       project?: string;
     };
     assert.ok(body);
-    assert.deepStrictEqual(body.extendedSnaps, skippedExamples);
+    assert.deepStrictEqual(body.extendedSnaps, skip);
     assert.strictEqual(body.extendsSha, 'baseline-sha');
     assert.strictEqual(body.project, 'test-project');
   });
@@ -76,7 +76,7 @@ describe('createExtendsReportSnapRequest', () => {
   it('returns the requestId from the response', async () => {
     const result = await createExtendsReportSnapRequest(
       'baseline-sha',
-      skippedExamples,
+      skip,
       config,
     );
 
@@ -97,7 +97,7 @@ describe('createExtendsReportSnapRequest', () => {
     makeHappoAPIRequestImpl = async () => ({ status: 'ok' });
 
     await assert.rejects(
-      () => createExtendsReportSnapRequest('baseline-sha', skippedExamples, config),
+      () => createExtendsReportSnapRequest('baseline-sha', skip, config),
       /Invalid response from extends-report snap request API/,
     );
   });
@@ -106,7 +106,7 @@ describe('createExtendsReportSnapRequest', () => {
     makeHappoAPIRequestImpl = async () => ({ requestId: 'not-a-number' });
 
     await assert.rejects(
-      () => createExtendsReportSnapRequest('baseline-sha', skippedExamples, config),
+      () => createExtendsReportSnapRequest('baseline-sha', skip, config),
       /Invalid response from extends-report snap request API/,
     );
   });
@@ -117,7 +117,7 @@ describe('createExtendsReportSnapRequest', () => {
     };
 
     await assert.rejects(
-      () => createExtendsReportSnapRequest('baseline-sha', skippedExamples, config),
+      () => createExtendsReportSnapRequest('baseline-sha', skip, config),
       /network failure/,
     );
   });

--- a/src/network/__tests__/findBaselineReport.test.ts
+++ b/src/network/__tests__/findBaselineReport.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert';
+import type { Mock } from 'node:test';
+import { beforeEach, describe, it, mock } from 'node:test';
+
+import type { ConfigWithDefaults } from '../../config/index.ts';
+import type { EnvironmentResult } from '../../environment/index.ts';
+import type makeHappoAPIRequest from '../makeHappoAPIRequest.ts';
+
+interface TestLogger {
+  log: Mock<Console['log']>;
+  error: Mock<Console['error']>;
+}
+
+type MakeHappoAPIRequestImpl = (...args: Array<unknown>) => Promise<object | null>;
+
+let makeHappoAPIRequestImpl: MakeHappoAPIRequestImpl;
+const makeHappoAPIRequestMock: Mock<typeof makeHappoAPIRequest> = mock.fn(
+  async (...args: Array<unknown>) => {
+    return await makeHappoAPIRequestImpl(...args);
+  },
+);
+
+mock.module('../makeHappoAPIRequest.ts', {
+  defaultExport: makeHappoAPIRequestMock,
+});
+
+let logger: TestLogger;
+let config: ConfigWithDefaults;
+let environment: EnvironmentResult;
+let findBaselineReport: typeof import('../findBaselineReport.ts').default;
+
+beforeEach(async () => {
+  logger = {
+    log: mock.fn(),
+    error: mock.fn(),
+  };
+
+  config = {
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+    endpoint: 'https://happo.io',
+    githubApiUrl: 'https://api.github.com',
+    project: 'test-project',
+    targets: {},
+    integration: { type: 'storybook' },
+  };
+
+  environment = {
+    beforeSha: 'before-sha',
+    afterSha: 'after-sha',
+    link: undefined,
+    message: undefined,
+    authorEmail: undefined,
+    nonce: undefined,
+    debugMode: false,
+    notify: undefined,
+    fallbackShas: ['fallback-sha-1', 'fallback-sha-2'],
+    githubToken: undefined,
+    ci: false,
+    skippedExamples: undefined,
+  };
+
+  makeHappoAPIRequestImpl = async () => ({ sha: 'baseline-sha-123' });
+
+  ({ default: findBaselineReport } = await import('../findBaselineReport.ts'));
+  makeHappoAPIRequestMock.mock.resetCalls();
+});
+
+describe('findBaselineReport', () => {
+  it('posts to the correct endpoint using afterSha', async () => {
+    await findBaselineReport(environment, config, logger);
+
+    assert.strictEqual(makeHappoAPIRequestMock.mock.callCount(), 1);
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+    assert.strictEqual(
+      call.arguments[0]?.path,
+      '/api/reports/after-sha/baseline-report',
+    );
+    assert.strictEqual(call.arguments[0]?.method, 'POST');
+  });
+
+  it('includes project and shas (beforeSha + fallbackShas) in the request body', async () => {
+    await findBaselineReport(environment, config, logger);
+
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+    const body = call.arguments[0]?.body as {
+      project?: string;
+      shas?: Array<string>;
+    };
+    assert.ok(body);
+    assert.strictEqual(body.project, 'test-project');
+    assert.deepStrictEqual(body.shas, [
+      'before-sha',
+      'fallback-sha-1',
+      'fallback-sha-2',
+    ]);
+  });
+
+  it('uses only beforeSha in shas when there are no fallbackShas', async () => {
+    environment.fallbackShas = undefined;
+
+    await findBaselineReport(environment, config, logger);
+
+    const call = makeHappoAPIRequestMock.mock.calls[0];
+    assert.ok(call);
+    const body = call.arguments[0]?.body as { shas?: Array<string> };
+    assert.ok(body);
+    assert.deepStrictEqual(body.shas, ['before-sha']);
+  });
+
+  it('returns the sha from the API response', async () => {
+    const result = await findBaselineReport(environment, config, logger);
+
+    assert.strictEqual(result, 'baseline-sha-123');
+  });
+
+  it('returns undefined when the response has no sha property', async () => {
+    makeHappoAPIRequestImpl = async () => ({ status: 'not-found' });
+
+    const result = await findBaselineReport(environment, config, logger);
+
+    assert.strictEqual(result, undefined);
+  });
+
+  it('returns undefined and logs an error when the request throws', async () => {
+    makeHappoAPIRequestImpl = async () => {
+      throw new Error('network failure');
+    };
+
+    const result = await findBaselineReport(environment, config, logger);
+
+    assert.strictEqual(result, undefined);
+    assert.strictEqual(logger.error.mock.callCount(), 1);
+  });
+});

--- a/src/network/__tests__/findBaselineReport.test.ts
+++ b/src/network/__tests__/findBaselineReport.test.ts
@@ -57,7 +57,7 @@ beforeEach(async () => {
     fallbackShas: ['fallback-sha-1', 'fallback-sha-2'],
     githubToken: undefined,
     ci: false,
-    skippedExamples: undefined,
+    skip: undefined,
   };
 
   makeHappoAPIRequestImpl = async () => ({ sha: 'baseline-sha-123' });

--- a/src/network/__tests__/findBaselineReport.test.ts
+++ b/src/network/__tests__/findBaselineReport.test.ts
@@ -75,7 +75,7 @@ describe('findBaselineReport', () => {
     assert.ok(call);
     assert.strictEqual(
       call.arguments[0]?.path,
-      '/api/reports/after-sha/baseline-report',
+      '/api/reports/after-sha/find-baseline',
     );
     assert.strictEqual(call.arguments[0]?.method, 'POST');
   });

--- a/src/network/createExtendsReportSnapRequest.ts
+++ b/src/network/createExtendsReportSnapRequest.ts
@@ -4,7 +4,7 @@ import makeHappoAPIRequest from './makeHappoAPIRequest.ts';
 
 export default async function createExtendsReportSnapRequest(
   extendsSha: string,
-  skippedExamples: Array<SkipItem>,
+  skip: Array<SkipItem>,
   config: ConfigWithDefaults,
 ): Promise<number> {
   const result = await makeHappoAPIRequest(
@@ -12,7 +12,7 @@ export default async function createExtendsReportSnapRequest(
       path: '/api/snap-requests/extends-report',
       method: 'POST',
       body: {
-        extendedSnaps: skippedExamples,
+        extendedSnaps: skip,
         extendsSha,
         project: config.project,
       },

--- a/src/network/createExtendsReportSnapRequest.ts
+++ b/src/network/createExtendsReportSnapRequest.ts
@@ -22,7 +22,7 @@ export default async function createExtendsReportSnapRequest(
   );
 
   if (!result || !('requestId' in result) || typeof result.requestId !== 'number') {
-    throw new Error('Invalid response from extends-report snap request API');
+    throw new Error(`Invalid response from extends-report snap request API: ${JSON.stringify(result)}`);
   }
 
   return result.requestId;

--- a/src/network/createExtendsReportSnapRequest.ts
+++ b/src/network/createExtendsReportSnapRequest.ts
@@ -1,0 +1,29 @@
+import type { ConfigWithDefaults } from '../config/index.ts';
+import type { SkipItem } from '../isomorphic/types.ts';
+import makeHappoAPIRequest from './makeHappoAPIRequest.ts';
+
+export default async function createExtendsReportSnapRequest(
+  extendsSha: string,
+  skippedExamples: Array<SkipItem>,
+  config: ConfigWithDefaults,
+): Promise<number> {
+  const result = await makeHappoAPIRequest(
+    {
+      path: '/api/snap-requests/extends-report',
+      method: 'POST',
+      body: {
+        extendedSnaps: skippedExamples,
+        extendsSha,
+        project: config.project,
+      },
+    },
+    config,
+    { retryCount: 3 },
+  );
+
+  if (!result || !('requestId' in result) || typeof result.requestId !== 'number') {
+    throw new Error('Invalid response from extends-report snap request API');
+  }
+
+  return result.requestId;
+}

--- a/src/network/findBaselineReport.ts
+++ b/src/network/findBaselineReport.ts
@@ -1,0 +1,36 @@
+import type { ConfigWithDefaults } from '../config/index.ts';
+import type { EnvironmentResult } from '../environment/index.ts';
+import type { Logger } from '../isomorphic/types.ts';
+import makeHappoAPIRequest from './makeHappoAPIRequest.ts';
+
+export default async function findBaselineReport(
+  environment: EnvironmentResult,
+  config: ConfigWithDefaults,
+  logger: Logger,
+): Promise<string | undefined> {
+  const shas = [environment.beforeSha, ...(environment.fallbackShas ?? [])].filter(Boolean);
+
+  try {
+    const result = await makeHappoAPIRequest(
+      {
+        path: `/api/reports/${environment.afterSha}/baseline-report`,
+        method: 'POST',
+        body: {
+          project: config.project,
+          shas,
+        },
+      },
+      config,
+      { retryCount: 2 },
+      logger,
+    );
+
+    if (result && 'sha' in result && typeof result.sha === 'string') {
+      return result.sha;
+    }
+  } catch (e) {
+    logger.error('[HAPPO] Failed to find baseline report:', e);
+  }
+
+  return undefined;
+}

--- a/src/network/findBaselineReport.ts
+++ b/src/network/findBaselineReport.ts
@@ -28,6 +28,7 @@ export default async function findBaselineReport(
     if (result && 'sha' in result && typeof result.sha === 'string') {
       return result.sha;
     }
+    throw new Error(`Unexpected response from find-baseline API: ${JSON.stringify(result)}`);
   } catch (e) {
     logger.error('[HAPPO] Failed to find baseline report:', e);
   }

--- a/src/network/findBaselineReport.ts
+++ b/src/network/findBaselineReport.ts
@@ -13,7 +13,7 @@ export default async function findBaselineReport(
   try {
     const result = await makeHappoAPIRequest(
       {
-        path: `/api/reports/${environment.afterSha}/baseline-report`,
+        path: `/api/reports/${environment.afterSha}/find-baseline`,
         method: 'POST',
         body: {
           project: config.project,

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -61,10 +61,13 @@ async function injectSkippedIntoIframe(
   skipped: Array<{ component: string; variant: string }>,
 ): Promise<void> {
   const content = await fs.promises.readFile(iframePath, 'utf8');
-  const injected = content.replace(
-    '<head>',
-    `<head><script type="text/javascript">window.happoSkipped = ${JSON.stringify(skipped)};</script>`,
-  );
+  const skippedScript = `<script type="text/javascript">window.happoSkipped = ${JSON.stringify(skipped)};</script>`;
+  const injected = content.replace(/<head\b[^>]*>/i, (match) => `${match}${skippedScript}`);
+  if (injected === content) {
+    throw new Error(
+      `Failed to inject skipped examples into iframe.html at '${iframePath}': could not find an opening <head> tag`,
+    );
+  }
   await fs.promises.writeFile(iframePath, injected);
 }
 

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { ConfigWithDefaults } from '../config/index.ts';
+import type { SkipItem } from '../isomorphic/types.ts';
 import RemoteBrowserTarget, {
   type ExecuteParams,
 } from '../config/RemoteBrowserTarget.ts';
@@ -58,7 +59,7 @@ interface BuildPackageResult {
 
 async function injectSkippedIntoIframe(
   iframePath: string,
-  skipped: Array<{ component: string; variant: string }>,
+  skipped: Array<SkipItem>,
 ): Promise<void> {
   const content = await fs.promises.readFile(iframePath, 'utf8');
   const skippedScript = `<script type="text/javascript">window.happoSkipped = ${JSON.stringify(skipped)};</script>`;
@@ -74,7 +75,7 @@ async function injectSkippedIntoIframe(
 async function buildPackage(
   { integration }: ConfigWithDefaults,
   logger: Logger,
-  skippedExamples?: Array<{ component: string; variant: string }>,
+  skippedExamples?: Array<SkipItem>,
 ): Promise<BuildPackageResult> {
   if (integration.type === 'custom') {
     const { rootDir, entryPoint, estimatedSnapsCount } = await integration.build();
@@ -120,7 +121,7 @@ interface PreparePackageResult {
 async function preparePackage(
   config: ConfigWithDefaults,
   logger: Logger,
-  skippedExamples?: Array<{ component: string; variant: string }>,
+  skippedExamples?: Array<SkipItem>,
 ): Promise<PreparePackageResult> {
   const { packageDir, estimatedSnapsCount } = await buildPackage(config, logger, skippedExamples);
 
@@ -145,7 +146,7 @@ async function preparePackage(
 
 export default async function prepareSnapRequests(
   config: ConfigWithDefaults,
-  skippedExamples?: Array<{ component: string; variant: string }>,
+  skippedExamples?: Array<SkipItem>,
 ): Promise<Array<number>> {
   const logger = new Logger();
   const prepareResult =

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -2,10 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { ConfigWithDefaults } from '../config/index.ts';
-import type { SkipItem } from '../isomorphic/types.ts';
 import RemoteBrowserTarget, {
   type ExecuteParams,
 } from '../config/RemoteBrowserTarget.ts';
+import type { SkipItem } from '../isomorphic/types.ts';
 import buildStorybookPackage from '../storybook/index.ts';
 import deterministicArchive from '../utils/deterministicArchive.ts';
 import Logger, { logTag } from '../utils/Logger.ts';
@@ -62,7 +62,8 @@ async function injectSkippedIntoIframe(
   skipped: Array<SkipItem>,
 ): Promise<void> {
   const content = await fs.promises.readFile(iframePath, 'utf8');
-  const skippedScript = `<script type="text/javascript">window.happoSkipped = ${JSON.stringify(skipped)};</script>`;
+  const skippedJson = JSON.stringify(skipped).replaceAll(/<\/script>/gi, String.raw`<\/script>`);
+  const skippedScript = `<script type="application/json" id="happo-skipped">${skippedJson}</script>`;
   const injected = content.replace(/<head\b[^>]*>/i, (match) => `${match}${skippedScript}`);
   if (injected === content) {
     throw new Error(

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -76,15 +76,15 @@ async function injectSkippedIntoIframe(
 async function buildPackage(
   { integration }: ConfigWithDefaults,
   logger: Logger,
-  skippedExamples?: Array<SkipItem>,
+  skip?: Array<SkipItem>,
 ): Promise<BuildPackageResult> {
   if (integration.type === 'custom') {
     const { rootDir, entryPoint, estimatedSnapsCount } = await integration.build();
     await createIframeHTML(rootDir, entryPoint, logger);
 
-    if (skippedExamples && skippedExamples.length > 0) {
+    if (skip && skip.length > 0) {
       const iframePath = path.join(rootDir, 'iframe.html');
-      await injectSkippedIntoIframe(iframePath, skippedExamples);
+      await injectSkippedIntoIframe(iframePath, skip);
     }
 
     const result: BuildPackageResult = { packageDir: rootDir };
@@ -97,7 +97,7 @@ async function buildPackage(
   if (integration.type === 'storybook') {
     return await buildStorybookPackage({
       ...integration,
-      ...(skippedExamples === undefined ? {} : { skippedExamples }),
+      ...(skip === undefined ? {} : { skip }),
     });
   }
 
@@ -122,9 +122,9 @@ interface PreparePackageResult {
 async function preparePackage(
   config: ConfigWithDefaults,
   logger: Logger,
-  skippedExamples?: Array<SkipItem>,
+  skip?: Array<SkipItem>,
 ): Promise<PreparePackageResult> {
-  const { packageDir, estimatedSnapsCount } = await buildPackage(config, logger, skippedExamples);
+  const { packageDir, estimatedSnapsCount } = await buildPackage(config, logger, skip);
 
   await validatePackage(packageDir);
 
@@ -147,13 +147,13 @@ async function preparePackage(
 
 export default async function prepareSnapRequests(
   config: ConfigWithDefaults,
-  skippedExamples?: Array<SkipItem>,
+  skip?: Array<SkipItem>,
 ): Promise<Array<number>> {
   const logger = new Logger();
   const prepareResult =
     config.integration.type === 'pages'
       ? null
-      : await preparePackage(config, logger, skippedExamples);
+      : await preparePackage(config, logger, skip);
 
   const targetNames = Object.keys(config.targets);
   const tl = targetNames.length;

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -56,13 +56,31 @@ interface BuildPackageResult {
   estimatedSnapsCount?: number;
 }
 
+async function injectSkippedIntoIframe(
+  iframePath: string,
+  skipped: Array<{ component: string; variant: string }>,
+): Promise<void> {
+  const content = await fs.promises.readFile(iframePath, 'utf8');
+  const injected = content.replace(
+    '<head>',
+    `<head><script type="text/javascript">window.happoSkipped = ${JSON.stringify(skipped)};</script>`,
+  );
+  await fs.promises.writeFile(iframePath, injected);
+}
+
 async function buildPackage(
   { integration }: ConfigWithDefaults,
   logger: Logger,
+  skippedExamples?: Array<{ component: string; variant: string }>,
 ): Promise<BuildPackageResult> {
   if (integration.type === 'custom') {
     const { rootDir, entryPoint, estimatedSnapsCount } = await integration.build();
     await createIframeHTML(rootDir, entryPoint, logger);
+
+    if (skippedExamples && skippedExamples.length > 0) {
+      const iframePath = path.join(rootDir, 'iframe.html');
+      await injectSkippedIntoIframe(iframePath, skippedExamples);
+    }
 
     const result: BuildPackageResult = { packageDir: rootDir };
     if (estimatedSnapsCount != null) {
@@ -72,7 +90,10 @@ async function buildPackage(
   }
 
   if (integration.type === 'storybook') {
-    return await buildStorybookPackage(integration);
+    return await buildStorybookPackage({
+      ...integration,
+      ...(skippedExamples === undefined ? {} : { skippedExamples }),
+    });
   }
 
   throw new Error(`Unsupported integration type: ${integration.type}`);
@@ -96,8 +117,9 @@ interface PreparePackageResult {
 async function preparePackage(
   config: ConfigWithDefaults,
   logger: Logger,
+  skippedExamples?: Array<{ component: string; variant: string }>,
 ): Promise<PreparePackageResult> {
-  const { packageDir, estimatedSnapsCount } = await buildPackage(config, logger);
+  const { packageDir, estimatedSnapsCount } = await buildPackage(config, logger, skippedExamples);
 
   await validatePackage(packageDir);
 
@@ -120,12 +142,13 @@ async function preparePackage(
 
 export default async function prepareSnapRequests(
   config: ConfigWithDefaults,
+  skippedExamples?: Array<{ component: string; variant: string }>,
 ): Promise<Array<number>> {
   const logger = new Logger();
   const prepareResult =
     config.integration.type === 'pages'
       ? null
-      : await preparePackage(config, logger);
+      : await preparePackage(config, logger, skippedExamples);
 
   const targetNames = Object.keys(config.targets);
   const tl = targetNames.length;

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -103,18 +103,19 @@ export const test: TestType<
         ? (integration.autoApplyPseudoStateAttributes ?? false)
         : false;
 
-    const partialSkipped: Array<{ component: string; variant: string }> = (() => {
+    const partialSkipped: Array<{ component: string; variant?: string }> = (() => {
       if (!process.env.HAPPO_SKIPPED_EXAMPLES) return [];
       try {
         const parsed: unknown = JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES);
         if (
           Array.isArray(parsed) &&
           parsed.every(
-            (item): item is { component: string; variant: string } =>
+            (item): item is { component: string; variant?: string } =>
               typeof item === 'object' &&
               item !== null &&
-              typeof item.component === 'string' &&
-              typeof item.variant === 'string',
+              typeof (item as Record<string, unknown>).component === 'string' &&
+              ((item as Record<string, unknown>).variant === undefined ||
+                typeof (item as Record<string, unknown>).variant === 'string'),
           )
         ) {
           return parsed;
@@ -150,7 +151,7 @@ export const test: TestType<
         throw new Error('Missing `variant`');
       }
 
-      if (partialSkipped.some((item) => item.component === component && item.variant === variant)) {
+      if (partialSkipped.some((item) => item.component === component && (item.variant === undefined || item.variant === variant))) {
         return;
       }
 

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -106,10 +106,20 @@ export const test: TestType<
     const partialSkipped: Array<{ component: string; variant: string }> = (() => {
       if (!process.env.HAPPO_SKIPPED_EXAMPLES) return [];
       try {
-        return JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES) as Array<{
-          component: string;
-          variant: string;
-        }>;
+        const parsed: unknown = JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES);
+        if (
+          Array.isArray(parsed) &&
+          parsed.every(
+            (item): item is { component: string; variant: string } =>
+              typeof item === 'object' &&
+              item !== null &&
+              typeof item.component === 'string' &&
+              typeof item.variant === 'string',
+          )
+        ) {
+          return parsed;
+        }
+        return [];
       } catch {
         return [];
       }

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -108,7 +108,11 @@ export const test: TestType<
         ? (integration.autoApplyPseudoStateAttributes ?? false)
         : false;
 
-    const skipSet = toSkipSet(parseSkippedExamples(process.env.HAPPO_SKIPPED_EXAMPLES));
+    const skippedFilePath = process.env.HAPPO_SKIPPED_EXAMPLES_FILE;
+    const rawSkipped = skippedFilePath
+      ? fs.readFileSync(skippedFilePath, 'utf8')
+      : undefined;
+    const skipSet = toSkipSet(parseSkippedExamples(rawSkipped));
 
     const happoScreenshot: ScreenshotFunction = async (
       handleOrLocator,

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -103,6 +103,18 @@ export const test: TestType<
         ? (integration.autoApplyPseudoStateAttributes ?? false)
         : false;
 
+    const partialSkipped: Array<{ component: string; variant: string }> = (() => {
+      if (!process.env.HAPPO_SKIPPED_EXAMPLES) return [];
+      try {
+        return JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES) as Array<{
+          component: string;
+          variant: string;
+        }>;
+      } catch {
+        return [];
+      }
+    })();
+
     const happoScreenshot: ScreenshotFunction = async (
       handleOrLocator,
       { component, variant, snapshotStrategy = 'hoist', ...rest },
@@ -126,6 +138,10 @@ export const test: TestType<
       }
       if (!variant) {
         throw new Error('Missing `variant`');
+      }
+
+      if (partialSkipped.some((item) => item.component === component && item.variant === variant)) {
+        return;
       }
 
       const elementHandle =

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -16,9 +16,9 @@ import { test as base } from '@playwright/test';
 import Controller from '../e2e/controller.ts';
 import {
   isInSkipSet,
-  parseSkippedExamples,
+  parseSkip,
   toSkipSet,
-} from '../isomorphic/parseSkippedExamples.ts';
+} from '../isomorphic/parseSkip.ts';
 
 const pathToBrowserBuild = path.resolve(
   import.meta.dirname,
@@ -108,11 +108,11 @@ export const test: TestType<
         ? (integration.autoApplyPseudoStateAttributes ?? false)
         : false;
 
-    const skippedFilePath = process.env.HAPPO_SKIPPED_EXAMPLES_FILE;
+    const skippedFilePath = process.env.HAPPO_SKIP_FILE;
     const rawSkipped = skippedFilePath
       ? fs.readFileSync(skippedFilePath, 'utf8')
       : undefined;
-    const skipSet = toSkipSet(parseSkippedExamples(rawSkipped));
+    const skipSet = toSkipSet(parseSkip(rawSkipped));
 
     const happoScreenshot: ScreenshotFunction = async (
       handleOrLocator,

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -14,6 +14,11 @@ import type {
 import { test as base } from '@playwright/test';
 
 import Controller from '../e2e/controller.ts';
+import {
+  isInSkipSet,
+  parseSkippedExamples,
+  toSkipSet,
+} from '../isomorphic/parseSkippedExamples.ts';
 
 const pathToBrowserBuild = path.resolve(
   import.meta.dirname,
@@ -103,28 +108,7 @@ export const test: TestType<
         ? (integration.autoApplyPseudoStateAttributes ?? false)
         : false;
 
-    const partialSkipped: Array<{ component: string; variant?: string }> = (() => {
-      if (!process.env.HAPPO_SKIPPED_EXAMPLES) return [];
-      try {
-        const parsed: unknown = JSON.parse(process.env.HAPPO_SKIPPED_EXAMPLES);
-        if (
-          Array.isArray(parsed) &&
-          parsed.every(
-            (item): item is { component: string; variant?: string } =>
-              typeof item === 'object' &&
-              item !== null &&
-              typeof (item as Record<string, unknown>).component === 'string' &&
-              ((item as Record<string, unknown>).variant === undefined ||
-                typeof (item as Record<string, unknown>).variant === 'string'),
-          )
-        ) {
-          return parsed;
-        }
-        return [];
-      } catch {
-        return [];
-      }
-    })();
+    const skipSet = toSkipSet(parseSkippedExamples(process.env.HAPPO_SKIPPED_EXAMPLES));
 
     const happoScreenshot: ScreenshotFunction = async (
       handleOrLocator,
@@ -151,7 +135,7 @@ export const test: TestType<
         throw new Error('Missing `variant`');
       }
 
-      if (partialSkipped.some((item) => item.component === component && (item.variant === undefined || item.variant === variant))) {
+      if (isInSkipSet(skipSet, component, variant)) {
         return;
       }
 

--- a/src/storybook/browser/register.ts
+++ b/src/storybook/browser/register.ts
@@ -378,7 +378,7 @@ globalThis.happo.nextExample = async (): Promise<NextExampleResult | undefined> 
     if (
       globalThis.happoSkipped &&
       globalThis.happoSkipped.some(
-        (item) => item.component === component && item.variant === variant,
+        (item) => item.component === component && (item.variant === undefined || item.variant === variant),
       )
     ) {
       console.log(`Skipping ${component}, ${variant} since it is in the skip list`);

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -96,7 +96,7 @@ export default async function buildStorybookPackage({
   usePrebuiltPackage = false,
   skippedExamples,
 }: Omit<StorybookIntegration, 'type'> & {
-  skippedExamples?: Array<{ component: string; variant: string }>;
+  skippedExamples?: Array<{ component: string; variant?: string }>;
 }): Promise<BuildStorybookPackageResult> {
   if (!usePrebuiltPackage) {
     await buildStorybook({ configDir, staticDir, outputDir });

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { StorybookIntegration } from '../config/index.ts';
+import type { SkipItem } from '../isomorphic/types.ts';
 import getStorybookBuildCommandParts from './getStorybookBuildCommandParts.ts';
 import getStorybookStoryCount from './getStorybookStoryCount.ts';
 import getStorybookVersionFromPackageJson from './getStorybookVersionFromPackageJson.ts';
@@ -96,7 +97,7 @@ export default async function buildStorybookPackage({
   usePrebuiltPackage = false,
   skippedExamples,
 }: Omit<StorybookIntegration, 'type'> & {
-  skippedExamples?: Array<{ component: string; variant?: string }>;
+  skippedExamples?: Array<SkipItem>;
 }): Promise<BuildStorybookPackageResult> {
   if (!usePrebuiltPackage) {
     await buildStorybook({ configDir, staticDir, outputDir });

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -6,21 +6,8 @@ import type { StorybookIntegration } from '../config/index.ts';
 import getStorybookBuildCommandParts from './getStorybookBuildCommandParts.ts';
 import getStorybookStoryCount from './getStorybookStoryCount.ts';
 import getStorybookVersionFromPackageJson from './getStorybookVersionFromPackageJson.ts';
-import type { SkipItems } from './isomorphic/types.ts';
 
 const { HAPPO_DEBUG } = process.env;
-
-function assertSkippedIsSkipItems(skipped: unknown): asserts skipped is SkipItems {
-  if (!Array.isArray(skipped)) {
-    throw new TypeError(`The \`skip\` option didn't provide an array`);
-  }
-
-  if (skipped.some((item) => !item.component || !item.variant)) {
-    throw new Error(
-      `Each item provided by the \`skip\` option needs a \`component\` and a \`variant\` property`,
-    );
-  }
-}
 
 function resolveBuildCommandParts() {
   const version = getStorybookVersionFromPackageJson();
@@ -107,8 +94,10 @@ export default async function buildStorybookPackage({
   staticDir,
   outputDir = '.out',
   usePrebuiltPackage = false,
-  skip,
-}: Omit<StorybookIntegration, 'type'>): Promise<BuildStorybookPackageResult> {
+  skippedExamples,
+}: Omit<StorybookIntegration, 'type'> & {
+  skippedExamples?: Array<{ component: string; variant: string }>;
+}): Promise<BuildStorybookPackageResult> {
   if (!usePrebuiltPackage) {
     await buildStorybook({ configDir, staticDir, outputDir });
   }
@@ -121,11 +110,6 @@ export default async function buildStorybookPackage({
   }
 
   try {
-    const skipped =
-      typeof skip === 'function' ? await skip() : Array.isArray(skip) ? skip : [];
-
-    assertSkippedIsSkipItems(skipped);
-
     const iframeContent = await fs.promises.readFile(iframePath, 'utf8');
 
     await fs.promises.writeFile(
@@ -136,7 +120,7 @@ export default async function buildStorybookPackage({
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <script type="text/javascript">window.__IS_HAPPO_RUN = true;</script>
             <script type="text/javascript">window.happoSkipped = ${JSON.stringify(
-              skipped,
+              skippedExamples ?? [],
             )};</script>
           `,
       ),

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -95,9 +95,9 @@ export default async function buildStorybookPackage({
   staticDir,
   outputDir = '.out',
   usePrebuiltPackage = false,
-  skippedExamples,
+  skip,
 }: Omit<StorybookIntegration, 'type'> & {
-  skippedExamples?: Array<SkipItem>;
+  skip?: Array<SkipItem>;
 }): Promise<BuildStorybookPackageResult> {
   if (!usePrebuiltPackage) {
     await buildStorybook({ configDir, staticDir, outputDir });
@@ -121,7 +121,7 @@ export default async function buildStorybookPackage({
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <script type="text/javascript">window.__IS_HAPPO_RUN = true;</script>
             <script type="text/javascript">window.happoSkipped = ${JSON.stringify(
-              skippedExamples ?? [],
+              skip ?? [],
             )};</script>
           `,
       ),


### PR DESCRIPTION
## Summary

- Adds a \`--skip\` CLI argument accepting a JSON array of \`{component, variant?}\` objects to skip in a run
- When skipped examples are provided, happo calls \`POST /api/reports/:sha/find-baseline\` to find a baseline SHA; if found, creates an extends-report snap request (\`POST /api/snap-requests/extends-report\`) with \`{extendedSnaps, extendsSha, project}\`; if no baseline is found, falls back to a full run
- Injects a \`<script type="application/json" id="happo-skipped">\` data block into \`iframe.html\` for Storybook/Custom integrations; writes a temp file and passes \`HAPPO_SKIP_FILE\` env var for Cypress/Playwright (avoids env var size limits)
- Shared \`parseSkip\` / \`validateSkip\` / \`toSkipSet\` / \`isInSkipSet\` helpers in \`src/isomorphic/parseSkip.ts\`; O(1) skip lookups via \`SkipSet\`
- Omitting \`variant\` in a skip item skips all variants for that component
- Removes the legacy \`skip\` config option from \`StorybookIntegration\` in favour of the CLI argument
- Adds \`scripts/getSkip.ts\` and \`pnpm test:storybook:skipped\` for daily-rotating partial test runs

## Test plan

- [ ] \`pnpm build:types\` passes with no errors
- [ ] \`pnpm test\` passes (325 tests, 0 failures)
- [ ] \`pnpm test:storybook:skipped\` runs a partial storybook run with one example skipped (requires API credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)