### PR TITLE
Allow storyFile items in --skip for storybook integration

### DIFF
--- a/scripts/getSkip.ts
+++ b/scripts/getSkip.ts
@@ -1,13 +1,16 @@
 /**
- * Outputs a --skip JSON argument, cycling through a set of examples based on
- * the current day of the week so that a different example is skipped on each
- * day.
+ * Outputs a --skip JSON argument with two items, cycling through a set of
+ * examples based on the current day of the week so that different examples
+ * are skipped on each day.
+ *
+ * - One item uses the `component` form to skip a specific variant.
+ * - One item uses the `storyFile` form to skip all stories in a file.
  *
  * Usage:
  *   node scripts/getSkip.ts
  */
 
-const examples = [
+const componentExamples = [
   { component: 'Stories', variant: 'Button With Text [white]' },
   { component: 'Stories', variant: 'Misc Large [white]' },
   { component: 'Stories', variant: 'Button Firefox Only [white]' },
@@ -17,7 +20,13 @@ const examples = [
   { component: 'Stories', variant: 'Lazy [white]' },
 ];
 
-const day = new Date().getDay(); // 0 (Sun) – 6 (Sat)
-const skipped = examples[day % examples.length];
+const storyFileExamples = [
+  { storyFile: './src/storybook/__tests__/storybook-app/Interactive.stories.ts' },
+  { storyFile: './src/storybook/__tests__/storybook-app/Story.stories.ts' },
+];
 
-process.stdout.write(JSON.stringify([skipped]));
+const day = new Date().getDay(); // 0 (Sun) – 6 (Sat)
+const componentItem = componentExamples[day % componentExamples.length];
+const storyFileItem = storyFileExamples[day % storyFileExamples.length];
+
+process.stdout.write(JSON.stringify([componentItem, storyFileItem]));

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -677,6 +677,68 @@ describe('main', () => {
       });
     });
 
+    describe('--skip', () => {
+      it('fails when storyFile items are used with a non-storybook integration', async () => {
+        tmpfs.writeFile(
+          'happo.config.ts',
+          `export default {
+            integration: {
+              type: 'custom',
+              build: async () => ({
+                rootDir: ${JSON.stringify(tmpfs.fullPath('happo-custom'))},
+                entryPoint: 'bundle.js',
+              }),
+            },
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+          };`,
+        );
+
+        await main(
+          [
+            'npx',
+            'happo',
+            '--skip',
+            JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+          ],
+          logger,
+        );
+
+        assert.strictEqual(process.exitCode, 1);
+        assert.strictEqual(logger.error.mock.callCount(), 1);
+        assert.match(
+          logger.error.mock.calls[0]?.arguments[0],
+          /storyFile.*storybook/,
+        );
+      });
+
+      it('does not log a storyFile error when storyFile items are used with the storybook integration', async () => {
+        tmpfs.writeFile(
+          'happo.config.ts',
+          `export default {
+            integration: { type: 'storybook' },
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+          };`,
+        );
+
+        await main(
+          [
+            'npx',
+            'happo',
+            '--skip',
+            JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+          ],
+          logger,
+        );
+
+        const storyFileErrors = logger.error.mock.calls.filter((c) =>
+          String(c.arguments[0]).includes('storyFile'),
+        );
+        assert.strictEqual(storyFileErrors.length, 0);
+      });
+    });
+
     describe('dashdash command', () => {
       it('fails when no dashdash is provided', async () => {
         await main(['npx', 'happo', '--'], logger);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -383,7 +383,7 @@ async function handleDefaultCommand(
     // Prepare the snap requests for the job. This includes bundling static
     // assets and uploading them. Only pass the skip list when we have a
     // baseline to borrow the skipped examples from.
-    const snapRequestIds = await prepareSnapRequests(config, skip);
+    const { snapRequestIds, resolvedSkip } = await prepareSnapRequests(config, skip);
 
     let allSnapRequestIds = snapRequestIds;
 
@@ -391,9 +391,11 @@ async function handleDefaultCommand(
       const createExtendsReportSnapRequest = (
         await import('../network/createExtendsReportSnapRequest.ts')
       ).default;
+      // Use storybook-resolved skip (storyFile items expanded to component names)
+      // if available, otherwise fall back to the raw skip list.
       const extendsRequestId = await createExtendsReportSnapRequest(
         baselineSha,
-        skip,
+        resolvedSkip ?? skip,
         config,
       );
       allSnapRequestIds = [...snapRequestIds, extendsRequestId];

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -368,6 +368,17 @@ async function handleDefaultCommand(
         return;
       }
 
+      if (
+        config.integration.type !== 'storybook' &&
+        skip.some((item) => 'storyFile' in item)
+      ) {
+        logger.error(
+          `[HAPPO] storyFile items in --skip are only supported for the storybook integration (current integration: '${config.integration.type}')`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       const findBaselineReport = (
         await import('../network/findBaselineReport.ts')
       ).default;

--- a/src/cypress/index.ts
+++ b/src/cypress/index.ts
@@ -7,7 +7,7 @@ import {
   type SkipSet,
   toSkipSet,
 } from '../isomorphic/parseSkip.ts';
-import type { TakeDOMSnapshotOptions } from '../isomorphic/types.ts';
+import type { SkipItem, TakeDOMSnapshotOptions } from '../isomorphic/types.ts';
 import chunked from './chunked.ts';
 
 interface HappoScreenshotOptions {
@@ -207,7 +207,7 @@ Cypress.Commands.add(
     };
 
     if (cachedAutoApplyPseudoStateAttributes === null) {
-      cy.task<{ autoApplyPseudoStateAttributes: boolean; skip: Array<{ component: string; variant?: string }> } | null>(
+      cy.task<{ autoApplyPseudoStateAttributes: boolean; skip: Array<SkipItem> } | null>(
         'happoGetIntegrationConfig',
         null,
         { ...taskOptions, log: false },

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 
 import Controller, { type SnapshotRegistrationParams } from '../e2e/controller.ts';
 import { parseSkip } from '../isomorphic/parseSkip.ts';
+import type { SkipItem } from '../isomorphic/types.ts';
 
 const controller = new Controller();
 let disabledLogged = false;
@@ -44,7 +45,7 @@ function getCleanupTimeframe({
 
 interface HappoScreenshotConfig {
   autoApplyPseudoStateAttributes: boolean;
-  skip: Array<{ component: string; variant?: string }>;
+  skip: Array<SkipItem>;
 }
 
 interface HappoTask {

--- a/src/isomorphic/__tests__/parseSkip.test.ts
+++ b/src/isomorphic/__tests__/parseSkip.test.ts
@@ -75,8 +75,8 @@ describe('validateSkip', () => {
 });
 
 describe('parseSkip', () => {
-  it('returns empty array for undefined', () => {
-    assert.deepStrictEqual(parseSkip(undefined), []);
+  it('returns empty array when called with no argument', () => {
+    assert.deepStrictEqual(parseSkip(), []);
   });
 
   it('returns empty array for invalid JSON', () => {

--- a/src/isomorphic/__tests__/parseSkip.test.ts
+++ b/src/isomorphic/__tests__/parseSkip.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { isInSkipSet, parseSkip, toSkipSet, validateSkip } from '../parseSkip.ts';
+
+describe('validateSkip', () => {
+  it('accepts component items', () => {
+    const result = validateSkip(JSON.stringify([{ component: 'Button', variant: 'Primary' }]));
+    assert.deepStrictEqual(result, [{ component: 'Button', variant: 'Primary' }]);
+  });
+
+  it('accepts component items without variant', () => {
+    const result = validateSkip(JSON.stringify([{ component: 'Button' }]));
+    assert.deepStrictEqual(result, [{ component: 'Button' }]);
+  });
+
+  it('accepts storyFile items', () => {
+    const result = validateSkip(
+      JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+    );
+    assert.deepStrictEqual(result, [{ storyFile: './src/Button.stories.tsx' }]);
+  });
+
+  it('rejects storyFile items with variant', () => {
+    assert.throws(
+      () =>
+        validateSkip(
+          JSON.stringify([{ storyFile: './src/Button.stories.tsx', variant: 'Primary' }]),
+        ),
+      TypeError,
+    );
+  });
+
+  it('accepts a mix of component and storyFile items', () => {
+    const items = [
+      { component: 'Button', variant: 'Primary' },
+      { storyFile: './src/Input.stories.tsx' },
+    ];
+    const result = validateSkip(JSON.stringify(items));
+    assert.deepStrictEqual(result, items);
+  });
+
+  it('rejects items with both component and storyFile', () => {
+    assert.throws(
+      () => validateSkip(JSON.stringify([{ component: 'Button', storyFile: './foo.tsx' }])),
+      TypeError,
+    );
+  });
+
+  it('rejects items with neither component nor storyFile', () => {
+    assert.throws(
+      () => validateSkip(JSON.stringify([{ variant: 'Primary' }])),
+      TypeError,
+    );
+  });
+
+  it('rejects non-array JSON', () => {
+    assert.throws(() => validateSkip(JSON.stringify({ component: 'Button' })), TypeError);
+  });
+
+  it('throws on invalid JSON', () => {
+    assert.throws(() => validateSkip('not json'), SyntaxError);
+  });
+
+  it('error message mentions both forms', () => {
+    try {
+      validateSkip(JSON.stringify([{ invalid: true }]));
+      assert.fail('expected an error');
+    } catch (e) {
+      assert.ok(e instanceof TypeError);
+      assert.match(e.message, /storyFile/);
+      assert.match(e.message, /component/);
+    }
+  });
+});
+
+describe('parseSkip', () => {
+  it('returns empty array for undefined', () => {
+    assert.deepStrictEqual(parseSkip(undefined), []);
+  });
+
+  it('returns empty array for invalid JSON', () => {
+    assert.deepStrictEqual(parseSkip('not json'), []);
+  });
+
+  it('returns parsed items for valid JSON', () => {
+    const items = [
+      { component: 'Button' },
+      { storyFile: './src/Input.stories.tsx' },
+    ];
+    assert.deepStrictEqual(parseSkip(JSON.stringify(items)), items);
+  });
+});
+
+describe('toSkipSet', () => {
+  it('builds a skip set from component items', () => {
+    const set = toSkipSet([
+      { component: 'Button', variant: 'Primary' },
+      { component: 'Input' },
+    ]);
+    assert.ok(isInSkipSet(set, 'Button', 'Primary'));
+    assert.ok(isInSkipSet(set, 'Input', 'Default'));
+    assert.ok(!isInSkipSet(set, 'Button', 'Secondary'));
+  });
+
+  it('ignores storyFile items', () => {
+    const set = toSkipSet([{ storyFile: './src/Button.stories.tsx' }]);
+    // No component-based entries, so nothing is skipped
+    assert.ok(!isInSkipSet(set, 'Button', 'Primary'));
+  });
+
+  it('handles a mix of component and storyFile items', () => {
+    const set = toSkipSet([
+      { component: 'Card' },
+      { storyFile: './src/Button.stories.tsx' },
+    ]);
+    assert.ok(isInSkipSet(set, 'Card', 'Default'));
+    assert.ok(!isInSkipSet(set, 'Button', 'Primary'));
+  });
+});

--- a/src/isomorphic/parseSkip.ts
+++ b/src/isomorphic/parseSkip.ts
@@ -10,10 +10,12 @@ export type SkipSet = readonly [componentOnly: Set<string>, componentVariant: Se
 function isSkipItem(item: unknown): item is SkipItem {
   if (typeof item !== 'object' || item === null) return false;
   const record = item as Record<string, unknown>;
-  return (
-    typeof record['component'] === 'string' &&
-    (record['variant'] === undefined || typeof record['variant'] === 'string')
-  );
+  const hasComponent = typeof record['component'] === 'string';
+  const hasStoryFile = typeof record['storyFile'] === 'string';
+  if (hasComponent && hasStoryFile) return false;
+  if (hasStoryFile) return record['variant'] === undefined;
+  if (hasComponent) return record['variant'] === undefined || typeof record['variant'] === 'string';
+  return false;
 }
 
 /**
@@ -24,7 +26,7 @@ export function validateSkip(json: string): Array<SkipItem> {
   const parsed: unknown = JSON.parse(json);
   if (!Array.isArray(parsed) || !parsed.every(isSkipItem)) {
     throw new TypeError(
-      '--skip must be a JSON array of {component, variant?} objects',
+      '--skip must be a JSON array of {component, variant?} or {storyFile, variant?} objects',
     );
   }
   return parsed;
@@ -45,11 +47,14 @@ export function parseSkip(json: string | undefined): Array<SkipItem> {
 
 /**
  * Converts an array of SkipItems into a SkipSet for efficient lookups.
+ * Items with a `storyFile` key (unresolved) are silently ignored.
  */
 export function toSkipSet(items: Array<SkipItem>): SkipSet {
   const componentOnly = new Set<string>();
   const componentVariant = new Set<string>();
-  for (const { component, variant } of items) {
+  for (const item of items) {
+    if (!('component' in item)) continue;
+    const { component, variant } = item;
     if (variant === undefined) {
       componentOnly.add(component);
     } else {

--- a/src/isomorphic/parseSkip.ts
+++ b/src/isomorphic/parseSkip.ts
@@ -36,7 +36,7 @@ export function validateSkip(json: string): Array<SkipItem> {
  * Parses a JSON string into an array of SkipItems. Returns an empty array on
  * any parse error or if the value is not a valid array of SkipItems.
  */
-export function parseSkip(json: string | undefined): Array<SkipItem> {
+export function parseSkip(json?: string): Array<SkipItem> {
   if (!json) return [];
   try {
     return validateSkip(json);

--- a/src/isomorphic/parseSkip.ts
+++ b/src/isomorphic/parseSkip.ts
@@ -26,7 +26,7 @@ export function validateSkip(json: string): Array<SkipItem> {
   const parsed: unknown = JSON.parse(json);
   if (!Array.isArray(parsed) || !parsed.every(isSkipItem)) {
     throw new TypeError(
-      '--skip must be a JSON array of {component, variant?} or {storyFile, variant?} objects',
+      '--skip must be a JSON array of {component, variant?} or {storyFile} objects',
     );
   }
   return parsed;

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -79,7 +79,6 @@ export interface WindowWithHappo extends Window {
 
 export type Logger = Pick<Console, 'log' | 'error'>;
 
-export interface SkipItem {
-  component: string;
-  variant?: string;
-}
+export type SkipItem =
+  | { component: string; variant?: string }
+  | { storyFile: string };

--- a/src/network/createExtendsReportSnapRequest.ts
+++ b/src/network/createExtendsReportSnapRequest.ts
@@ -12,7 +12,9 @@ export default async function createExtendsReportSnapRequest(
       path: '/api/snap-requests/extends-report',
       method: 'POST',
       body: {
-        extendedSnaps: skip,
+        extendedSnaps: skip.filter(
+          (item): item is { component: string; variant?: string } => 'component' in item,
+        ),
         extendsSha,
         project: config.project,
       },

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -55,6 +55,7 @@ async function createIframeHTML(
 interface BuildPackageResult {
   packageDir: string;
   estimatedSnapsCount?: number;
+  resolvedSkip?: Array<{ component: string; variant?: string }>;
 }
 
 async function injectSkippedIntoIframe(
@@ -95,10 +96,11 @@ async function buildPackage(
   }
 
   if (integration.type === 'storybook') {
-    return await buildStorybookPackage({
+    const result = await buildStorybookPackage({
       ...integration,
       ...(skip === undefined ? {} : { skip }),
     });
+    return result;
   }
 
   throw new Error(`Unsupported integration type: ${integration.type}`);
@@ -117,6 +119,7 @@ async function validatePackage(packageDir: string): Promise<void> {
 interface PreparePackageResult {
   packagePath: string;
   estimatedSnapsCount?: number;
+  resolvedSkip?: Array<{ component: string; variant?: string }>;
 }
 
 async function preparePackage(
@@ -124,7 +127,7 @@ async function preparePackage(
   logger: Logger,
   skip?: Array<SkipItem>,
 ): Promise<PreparePackageResult> {
-  const { packageDir, estimatedSnapsCount } = await buildPackage(config, logger, skip);
+  const { packageDir, estimatedSnapsCount, resolvedSkip } = await buildPackage(config, logger, skip);
 
   await validatePackage(packageDir);
 
@@ -142,13 +145,21 @@ async function preparePackage(
   if (estimatedSnapsCount != null) {
     result.estimatedSnapsCount = estimatedSnapsCount;
   }
+  if (resolvedSkip !== undefined) {
+    result.resolvedSkip = resolvedSkip;
+  }
   return result;
+}
+
+export interface PrepareSnapRequestsResult {
+  snapRequestIds: Array<number>;
+  resolvedSkip?: Array<{ component: string; variant?: string }>;
 }
 
 export default async function prepareSnapRequests(
   config: ConfigWithDefaults,
   skip?: Array<SkipItem>,
-): Promise<Array<number>> {
+): Promise<PrepareSnapRequestsResult> {
   const logger = new Logger();
   const prepareResult =
     config.integration.type === 'pages'
@@ -163,7 +174,7 @@ export default async function prepareSnapRequests(
     }...`,
   );
   const outerStartTime = Date.now();
-  const results: Array<number> = [];
+  const snapRequestIds: Array<number> = [];
   await Promise.all(
     targetNames.map(async (name) => {
       const startTime = Date.now();
@@ -193,13 +204,17 @@ export default async function prepareSnapRequests(
         targetParams.pages = config.integration.pages;
       }
 
-      const snapRequestIds = await target.execute(targetParams, config);
+      const ids = await target.execute(targetParams, config);
       logger.start(`  - ${logTag(config.project)}${name}`, { startTime });
       logger.success();
-      results.push(...snapRequestIds);
+      snapRequestIds.push(...ids);
     }),
   );
   logger.start(undefined, { startTime: outerStartTime });
   logger.success();
-  return results;
+  const result: PrepareSnapRequestsResult = { snapRequestIds };
+  if (prepareResult?.resolvedSkip !== undefined) {
+    result.resolvedSkip = prepareResult.resolvedSkip;
+  }
+  return result;
 }

--- a/src/storybook/__tests__/resolveStoryFileItems.test.ts
+++ b/src/storybook/__tests__/resolveStoryFileItems.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import resolveStoryFileItems, {
+  type StorybookIndexEntry,
+} from '../resolveStoryFileItems.ts';
+
+const entries: Record<string, StorybookIndexEntry> = {
+  'button--primary': {
+    type: 'story',
+    importPath: './src/Button.stories.tsx',
+    title: 'Button',
+  },
+  'button--secondary': {
+    type: 'story',
+    importPath: './src/Button.stories.tsx',
+    title: 'Button',
+  },
+  'input--default': {
+    type: 'story',
+    importPath: './src/Input.stories.tsx',
+    title: 'Input',
+  },
+  'card--default': {
+    type: 'story',
+    importPath: './src/components/Card.stories.tsx',
+    title: 'Card',
+  },
+};
+
+describe('resolveStoryFileItems', () => {
+  it('passes through component items unchanged', () => {
+    const result = resolveStoryFileItems(
+      [{ component: 'Button', variant: 'Primary' }],
+      entries,
+    );
+    assert.deepStrictEqual(result, [{ component: 'Button', variant: 'Primary' }]);
+  });
+
+  it('resolves storyFile to component name', () => {
+    const result = resolveStoryFileItems(
+      [{ storyFile: './src/Button.stories.tsx' }],
+      entries,
+    );
+    assert.deepStrictEqual(result, [{ component: 'Button' }]);
+  });
+
+  it('resolves storyFile without leading ./', () => {
+    const result = resolveStoryFileItems(
+      [{ storyFile: 'src/Input.stories.tsx' }],
+      entries,
+    );
+    assert.deepStrictEqual(result, [{ component: 'Input' }]);
+  });
+
+  it('returns one entry per unique component title, not per story', () => {
+    // Button has two stories but one title — should produce one resolved item
+    const result = resolveStoryFileItems(
+      [{ storyFile: 'src/Button.stories.tsx' }],
+      entries,
+    );
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]?.component, 'Button');
+  });
+
+  it('handles a mix of component and storyFile items', () => {
+    const result = resolveStoryFileItems(
+      [{ component: 'Card', variant: 'Default' }, { storyFile: 'src/Input.stories.tsx' }],
+      entries,
+    );
+    assert.deepStrictEqual(result, [
+      { component: 'Card', variant: 'Default' },
+      { component: 'Input' },
+    ]);
+  });
+
+  it('warns and skips storyFile items not found in the index', () => {
+    const warnings: Array<string> = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: string) => { warnings.push(msg); };
+    try {
+      const result = resolveStoryFileItems(
+        [{ storyFile: 'src/NotFound.stories.tsx' }],
+        entries,
+      );
+      assert.deepStrictEqual(result, []);
+      assert.strictEqual(warnings.length, 1);
+      assert.match(warnings[0] ?? '', /NotFound/);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('returns empty array for empty skip list', () => {
+    const result = resolveStoryFileItems([], entries);
+    assert.deepStrictEqual(result, []);
+  });
+
+  it('returns empty array when entries are empty', () => {
+    const warnings: Array<string> = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: string) => { warnings.push(msg); };
+    try {
+      const result = resolveStoryFileItems([{ storyFile: 'src/Button.stories.tsx' }], {});
+      assert.deepStrictEqual(result, []);
+      assert.strictEqual(warnings.length, 1);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/src/storybook/__tests__/resolveStoryFileItems.test.ts
+++ b/src/storybook/__tests__/resolveStoryFileItems.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
 
 import resolveStoryFileItems, {
   type StorybookIndexEntry,
@@ -75,19 +75,17 @@ describe('resolveStoryFileItems', () => {
   });
 
   it('warns and skips storyFile items not found in the index', () => {
-    const warnings: Array<string> = [];
-    const originalWarn = console.warn;
-    console.warn = (msg: string) => { warnings.push(msg); };
+    const warnMock = mock.method(console, 'warn', () => {});
     try {
       const result = resolveStoryFileItems(
         [{ storyFile: 'src/NotFound.stories.tsx' }],
         entries,
       );
       assert.deepStrictEqual(result, []);
-      assert.strictEqual(warnings.length, 1);
-      assert.match(warnings[0] ?? '', /NotFound/);
+      assert.strictEqual(warnMock.mock.callCount(), 1);
+      assert.match(String(warnMock.mock.calls[0]?.arguments[0]), /NotFound/);
     } finally {
-      console.warn = originalWarn;
+      warnMock.mock.restore();
     }
   });
 
@@ -97,15 +95,13 @@ describe('resolveStoryFileItems', () => {
   });
 
   it('returns empty array when entries are empty', () => {
-    const warnings: Array<string> = [];
-    const originalWarn = console.warn;
-    console.warn = (msg: string) => { warnings.push(msg); };
+    const warnMock = mock.method(console, 'warn', () => {});
     try {
       const result = resolveStoryFileItems([{ storyFile: 'src/Button.stories.tsx' }], {});
       assert.deepStrictEqual(result, []);
-      assert.strictEqual(warnings.length, 1);
+      assert.strictEqual(warnMock.mock.callCount(), 1);
     } finally {
-      console.warn = originalWarn;
+      warnMock.mock.restore();
     }
   });
 });

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -5,8 +5,8 @@ import path from 'node:path';
 import type { StorybookIntegration } from '../config/index.ts';
 import type { SkipItem } from '../isomorphic/types.ts';
 import getStorybookBuildCommandParts from './getStorybookBuildCommandParts.ts';
-import getStorybookStoryCount from './getStorybookStoryCount.ts';
 import getStorybookVersionFromPackageJson from './getStorybookVersionFromPackageJson.ts';
+import resolveStoryFileItems, { type StorybookIndexEntry } from './resolveStoryFileItems.ts';
 
 const { HAPPO_DEBUG } = process.env;
 
@@ -88,6 +88,7 @@ async function buildStorybook({
 export interface BuildStorybookPackageResult {
   packageDir: string;
   estimatedSnapsCount?: number;
+  resolvedSkip?: Array<{ component: string; variant?: string }>;
 }
 
 export default async function buildStorybookPackage({
@@ -113,6 +114,34 @@ export default async function buildStorybookPackage({
   try {
     const iframeContent = await fs.promises.readFile(iframePath, 'utf8');
 
+    // Read index.json once to compute story count and resolve storyFile items.
+    let estimatedSnapsCount: number | undefined;
+    let resolvedSkip: Array<{ component: string; variant?: string }> | undefined;
+
+    const indexPath = path.join(outputDir, 'index.json');
+    try {
+      const indexContent = await fs.promises.readFile(indexPath, 'utf8');
+      const indexData = JSON.parse(indexContent) as {
+        entries?: Record<string, StorybookIndexEntry>;
+        stories?: Record<string, StorybookIndexEntry>;
+      };
+      const entries = indexData.entries ?? indexData.stories ?? {};
+
+      estimatedSnapsCount = Object.values(entries).filter((e) => e.type === 'story').length;
+
+      if (skip !== undefined) {
+        resolvedSkip = resolveStoryFileItems(skip, entries);
+      }
+    } catch (error) {
+      console.warn('[HAPPO] Failed to read Storybook index.json:', error);
+      if (skip !== undefined) {
+        // Fall back to passing through only component-based items
+        resolvedSkip = skip.filter(
+          (item): item is { component: string; variant?: string } => 'component' in item,
+        );
+      }
+    }
+
     await fs.promises.writeFile(
       iframePath,
       iframeContent.replace(
@@ -121,17 +150,18 @@ export default async function buildStorybookPackage({
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <script type="text/javascript">window.__IS_HAPPO_RUN = true;</script>
             <script type="text/javascript">window.happoSkipped = ${JSON.stringify(
-              skip ?? [],
+              resolvedSkip ?? [],
             )};</script>
           `,
       ),
     );
 
-    const estimatedSnapsCount = await getStorybookStoryCount(outputDir);
-
     const result: BuildStorybookPackageResult = { packageDir: outputDir };
     if (estimatedSnapsCount != null) {
       result.estimatedSnapsCount = estimatedSnapsCount;
+    }
+    if (resolvedSkip !== undefined) {
+      result.resolvedSkip = resolvedSkip;
     }
     return result;
   } catch (e) {

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -149,9 +149,7 @@ export default async function buildStorybookPackage({
         `<head>
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <script type="text/javascript">window.__IS_HAPPO_RUN = true;</script>
-            <script type="text/javascript">window.happoSkipped = ${JSON.stringify(
-              resolvedSkip ?? [],
-            )};</script>
+            <script type="text/javascript">window.happoSkipped = ${JSON.stringify(resolvedSkip ?? []).replaceAll(/<\/script>/gi, String.raw`<\/script>`)};</script>
           `,
       ),
     );

--- a/src/storybook/resolveStoryFileItems.ts
+++ b/src/storybook/resolveStoryFileItems.ts
@@ -1,0 +1,74 @@
+import path from 'node:path';
+
+import type { SkipItem } from '../isomorphic/types.ts';
+
+export interface StorybookIndexEntry {
+  type: string;
+  importPath?: string;
+  title?: string;
+}
+
+/**
+ * Resolves `storyFile` skip items to component-based skip items using the
+ * Storybook `index.json` entries. Items that already have a `component` are
+ * passed through unchanged.
+ *
+ * Path matching is done by normalising both the `importPath` from the index
+ * and the user-supplied `storyFile` (stripping a leading `./`), with an
+ * absolute-path fallback via `path.resolve`.
+ */
+export default function resolveStoryFileItems(
+  skip: Array<SkipItem>,
+  entries: Record<string, StorybookIndexEntry>,
+): Array<{ component: string; variant?: string }> {
+  const fileToComponents = new Map<string, Set<string>>();
+  for (const entry of Object.values(entries)) {
+    if (!entry.importPath || !entry.title) continue;
+    const normalized = normalizeImportPath(entry.importPath);
+    let set = fileToComponents.get(normalized);
+    if (!set) {
+      set = new Set();
+      fileToComponents.set(normalized, set);
+    }
+    set.add(entry.title);
+  }
+
+  const resolved: Array<{ component: string; variant?: string }> = [];
+
+  for (const item of skip) {
+    if ('component' in item) {
+      resolved.push(item);
+      continue;
+    }
+
+    const normalizedFile = normalizeImportPath(item.storyFile);
+    let components = fileToComponents.get(normalizedFile);
+
+    if (!components) {
+      // Fall back to absolute path comparison
+      const resolvedFile = path.resolve(item.storyFile);
+      for (const [normalizedImport, titles] of fileToComponents) {
+        if (path.resolve(normalizedImport) === resolvedFile) {
+          components = titles;
+          break;
+        }
+      }
+    }
+
+    if (components) {
+      for (const component of components) {
+        resolved.push({ component });
+      }
+    } else {
+      console.warn(
+        `[HAPPO] Could not find any stories for storyFile '${item.storyFile}' in the Storybook index`,
+      );
+    }
+  }
+
+  return resolved;
+}
+
+function normalizeImportPath(p: string): string {
+  return p.startsWith('./') ? p.slice(2) : p;
+}


### PR DESCRIPTION
## Summary

- Extends the `--skip` array to accept `{ storyFile: './path/to/stories.ts' }` items alongside the existing `{ component, variant? }` form
- After the storybook build, `storyFile` items are resolved to component names using the built `index.json` (via `importPath → title` mapping), then passed to both the iframe `happoSkipped` global and the extends-report API
- `storyFile` items with a `variant` are rejected as invalid — use `{ component, variant }` for variant-level skipping
- Path matching normalises `./`-prefixed import paths; absolute paths are handled via `path.resolve` fallback

## Test plan

- [ ] `pnpm test parseSkip` — new unit tests for `validateSkip`/`toSkipSet` with both item forms
- [ ] `pnpm test resolveStoryFileItems` — new unit tests for the file-path-to-component resolution logic
- [ ] `pnpm test` — full suite (349 pass, 0 fail)
- [ ] `pnpm build:types` — clean TypeScript compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)