### PR TITLE
Adjust auto-chunking to account for skipped stories

### DIFF
--- a/src/storybook/__tests__/index.test.ts
+++ b/src/storybook/__tests__/index.test.ts
@@ -26,4 +26,23 @@ describe('happoStorybookPlugin', () => {
     // 22 stories across Story.stories.ts (20) and Interactive.stories.ts (2)
     assert.strictEqual(estimatedSnapsCount, 22);
   });
+
+  describe('with --skip', () => {
+    it('reduces estimatedSnapsCount when skipping a whole component', async () => {
+      // Interactive has 2 stories (Demo + Interactive Throws Error)
+      const result = await happoStorybookPlugin({
+        usePrebuiltPackage: true,
+        skip: [{ component: 'Interactive' }],
+      });
+      assert.strictEqual(result.estimatedSnapsCount, 20);
+    });
+
+    it('reduces estimatedSnapsCount when skipping a single variant', async () => {
+      const result = await happoStorybookPlugin({
+        usePrebuiltPackage: true,
+        skip: [{ component: 'Stories', variant: 'Lazy' }],
+      });
+      assert.strictEqual(result.estimatedSnapsCount, 21);
+    });
+  });
 });

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { StorybookIntegration } from '../config/index.ts';
+import { isInSkipSet, toSkipSet } from '../isomorphic/parseSkip.ts';
 import type { SkipItem } from '../isomorphic/types.ts';
 import getStorybookBuildCommandParts from './getStorybookBuildCommandParts.ts';
 import getStorybookVersionFromPackageJson from './getStorybookVersionFromPackageJson.ts';
@@ -127,10 +128,17 @@ export default async function buildStorybookPackage({
       };
       const entries = indexData.entries ?? indexData.stories ?? {};
 
-      estimatedSnapsCount = Object.values(entries).filter((e) => e.type === 'story').length;
+      const storyEntries = Object.values(entries).filter((e) => e.type === 'story');
+      estimatedSnapsCount = storyEntries.length;
 
       if (skip !== undefined) {
         resolvedSkip = resolveStoryFileItems(skip, entries);
+        // Adjust the count so auto-chunking reflects only the stories that
+        // will actually be rendered (skipped examples don't need a chunk slot).
+        const skipSet = toSkipSet(resolvedSkip);
+        estimatedSnapsCount = storyEntries.filter(
+          (e) => !isInSkipSet(skipSet, e.title ?? '', e.name ?? ''),
+        ).length;
       }
     } catch (error) {
       console.warn('[HAPPO] Failed to read Storybook index.json:', error);

--- a/src/storybook/resolveStoryFileItems.ts
+++ b/src/storybook/resolveStoryFileItems.ts
@@ -6,6 +6,7 @@ export interface StorybookIndexEntry {
   type: string;
   importPath?: string;
   title?: string;
+  name?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- When `--skip` is used, `estimatedSnapsCount` previously reflected the total story count, causing auto-chunking to create more chunks than necessary
- After resolving skip items, the count is now filtered through the skip set so only stories that will actually render are counted
- Added `name?: string` to `StorybookIndexEntry` so variant-level skip items can be matched against index entries

## Test plan

- [ ] Run with `--skip` and verify chunk count scales down proportionally to the number of skipped stories
- [ ] Run without `--skip` and verify existing behaviour is unchanged (type-check + unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)