### PR TITLE
Rename storyFile to file; add file-based skip for E2E

### DIFF
--- a/scripts/getSkip.ts
+++ b/scripts/getSkip.ts
@@ -4,7 +4,7 @@
  * are skipped on each day.
  *
  * - One item uses the `component` form to skip a specific variant.
- * - One item uses the `storyFile` form to skip all stories in a file.
+ * - One item uses the `file` form to skip all stories in a file.
  *
  * Usage:
  *   node scripts/getSkip.ts
@@ -20,13 +20,13 @@ const componentExamples = [
   { component: 'Stories', variant: 'Lazy [white]' },
 ];
 
-const storyFileExamples = [
-  { storyFile: './src/storybook/__tests__/storybook-app/Interactive.stories.ts' },
-  { storyFile: './src/storybook/__tests__/storybook-app/Story.stories.ts' },
+const fileExamples = [
+  { file: './src/storybook/__tests__/storybook-app/Interactive.stories.ts' },
+  { file: './src/storybook/__tests__/storybook-app/Story.stories.ts' },
 ];
 
 const day = new Date().getDay(); // 0 (Sun) – 6 (Sat)
 const componentItem = componentExamples[day % componentExamples.length];
-const storyFileItem = storyFileExamples[day % storyFileExamples.length];
+const fileItem = fileExamples[day % fileExamples.length];
 
-process.stdout.write(JSON.stringify([componentItem, storyFileItem]));
+process.stdout.write(JSON.stringify([componentItem, fileItem]));

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -678,7 +678,7 @@ describe('main', () => {
     });
 
     describe('--skip', () => {
-      it('fails when storyFile items are used with a non-storybook integration', async () => {
+      it('fails when file items are used with a non-storybook integration', async () => {
         tmpfs.writeFile(
           'happo.config.ts',
           `export default {
@@ -699,7 +699,7 @@ describe('main', () => {
             'npx',
             'happo',
             '--skip',
-            JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+            JSON.stringify([{ file: './src/Button.stories.tsx' }]),
           ],
           logger,
         );
@@ -708,11 +708,11 @@ describe('main', () => {
         assert.strictEqual(logger.error.mock.callCount(), 1);
         assert.match(
           logger.error.mock.calls[0]?.arguments[0],
-          /storyFile.*storybook/,
+          /file.*storybook/,
         );
       });
 
-      it('does not log a storyFile error when storyFile items are used with the storybook integration', async () => {
+      it('does not log a file error when file items are used with the storybook integration', async () => {
         tmpfs.writeFile(
           'happo.config.ts',
           `export default {
@@ -727,15 +727,15 @@ describe('main', () => {
             'npx',
             'happo',
             '--skip',
-            JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+            JSON.stringify([{ file: './src/Button.stories.tsx' }]),
           ],
           logger,
         );
 
-        const storyFileErrors = logger.error.mock.calls.filter((c) =>
-          String(c.arguments[0]).includes('storyFile'),
+        const fileErrors = logger.error.mock.calls.filter((c) =>
+          String(c.arguments[0]).includes('file items'),
         );
-        assert.strictEqual(storyFileErrors.length, 0);
+        assert.strictEqual(fileErrors.length, 0);
       });
     });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -370,10 +370,10 @@ async function handleDefaultCommand(
 
       if (
         config.integration.type !== 'storybook' &&
-        skip.some((item) => 'storyFile' in item)
+        skip.some((item) => 'file' in item)
       ) {
         logger.error(
-          `[HAPPO] storyFile items in --skip are only supported for the storybook integration (current integration: '${config.integration.type}')`,
+          `[HAPPO] file items in --skip are only supported for the storybook integration (current integration: '${config.integration.type}')`,
         );
         process.exitCode = 1;
         return;
@@ -402,7 +402,7 @@ async function handleDefaultCommand(
       const createExtendsReportSnapRequest = (
         await import('../network/createExtendsReportSnapRequest.ts')
       ).default;
-      // Use storybook-resolved skip (storyFile items expanded to component names)
+      // Use storybook-resolved skip (file items expanded to component names)
       // if available, otherwise fall back to the raw skip list.
       const extendsRequestId = await createExtendsReportSnapRequest(
         baselineSha,

--- a/src/cypress/index.ts
+++ b/src/cypress/index.ts
@@ -111,6 +111,7 @@ let config: CypressConfig = {
 // Cached so the happoGetIntegrationConfig task is called at most once per run.
 let cachedAutoApplyPseudoStateAttributes: boolean | null = null;
 let cachedSkipSet: SkipSet | null = null;
+let cachedFileItems: Array<{ file: string }> | null = null;
 
 export const configure = (userConfig?: Partial<CypressConfig>): void => {
   config = { ...config, ...userConfig };
@@ -215,13 +216,39 @@ Cypress.Commands.add(
         cachedAutoApplyPseudoStateAttributes =
           happoSettings?.autoApplyPseudoStateAttributes ?? false;
         cachedSkipSet = toSkipSet(happoSettings?.skip ?? []);
-        if (isInSkipSet(cachedSkipSet, component, variant)) {
+        cachedFileItems = (happoSettings?.skip ?? []).filter(
+          (item): item is { file: string } => 'file' in item,
+        );
+        const skipByComponent = isInSkipSet(cachedSkipSet, component, variant);
+        const skipByFile = cachedFileItems.some(
+          (item) => item.file === Cypress.spec.absolute,
+        );
+        if (skipByComponent || skipByFile) {
+          if (skipByFile) {
+            cy.task(
+              'happoRecordResolvedSkip',
+              { component, variant },
+              { ...taskOptions, log: false },
+            );
+          }
           return;
         }
         takeSnapshot(cachedAutoApplyPseudoStateAttributes);
       });
     } else {
-      if (cachedSkipSet && isInSkipSet(cachedSkipSet, component, variant)) {
+      const skipByComponent =
+        cachedSkipSet !== null && isInSkipSet(cachedSkipSet, component, variant);
+      const skipByFile =
+        cachedFileItems !== null &&
+        cachedFileItems.some((item) => item.file === Cypress.spec.absolute);
+      if (skipByComponent || skipByFile) {
+        if (skipByFile) {
+          cy.task(
+            'happoRecordResolvedSkip',
+            { component, variant },
+            { ...taskOptions, log: false },
+          );
+        }
         return;
       }
       takeSnapshot(cachedAutoApplyPseudoStateAttributes);

--- a/src/cypress/task.ts
+++ b/src/cypress/task.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 import Controller, { type SnapshotRegistrationParams } from '../e2e/controller.ts';
 import { parseSkip } from '../isomorphic/parseSkip.ts';
@@ -63,6 +64,7 @@ interface HappoTask {
     isLast: boolean;
   }): Promise<null>;
   happoGetIntegrationConfig(): HappoScreenshotConfig;
+  happoRecordResolvedSkip(params: { component: string; variant: string }): null;
   handleBeforeSpec(): Promise<void>;
 }
 
@@ -74,6 +76,7 @@ const task: HappoTask = {
       happoRegisterSnapshot: task.happoRegisterSnapshot,
       happoRegisterBase64Image: task.happoRegisterBase64Image,
       happoGetIntegrationConfig: task.happoGetIntegrationConfig,
+      happoRecordResolvedSkip: task.happoRecordResolvedSkip,
     });
     on('before:spec', task.handleBeforeSpec);
     on('after:spec', task.handleAfterSpec);
@@ -155,7 +158,11 @@ const task: HappoTask = {
         console.warn('[HAPPO] Failed to read HAPPO_SKIP_FILE:', e);
       }
     }
-    const skip = parseSkip(rawSkipped);
+    // Resolve file item paths to absolute so the browser side can compare
+    // them directly to Cypress.spec.absolute.
+    const skip = parseSkip(rawSkipped).map((item): SkipItem =>
+      'file' in item ? { file: path.resolve(item.file) } : item,
+    );
     return {
       autoApplyPseudoStateAttributes:
         integration?.type === 'cypress'
@@ -163,6 +170,22 @@ const task: HappoTask = {
           : false,
       skip,
     };
+  },
+
+  happoRecordResolvedSkip({ component, variant }: { component: string; variant: string }): null {
+    const resolvedSkipFilePath = process.env.HAPPO_RESOLVED_SKIP_FILE;
+    if (resolvedSkipFilePath) {
+      try {
+        fs.appendFileSync(
+          resolvedSkipFilePath,
+          JSON.stringify({ component, variant }) + '\n',
+          'utf8',
+        );
+      } catch (e) {
+        console.warn('[HAPPO] Failed to write to HAPPO_RESOLVED_SKIP_FILE:', e);
+      }
+    }
+    return null;
   },
 
   async handleBeforeSpec(): Promise<void> {

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 import type { ConfigWithDefaults, E2EIntegration } from '../config/index.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
+import { parseSkip } from '../isomorphic/parseSkip.ts';
 import cancelJob from '../network/cancelJob.ts';
 import createAsyncComparison from '../network/createAsyncComparison.ts';
 import makeHappoAPIRequest from '../network/makeHappoAPIRequest.ts';
@@ -75,8 +76,42 @@ export async function finalizeAll({
 
   if (skipJSON) {
     try {
-      const skipItems = JSON.parse(skipJSON);
-      body.skip = skipItems;
+      const rawItems = parseSkip(skipJSON);
+      const componentItems = rawItems.filter(
+        (item): item is { component: string; variant?: string } => 'component' in item,
+      );
+      const fileItems = rawItems.filter((item): item is { file: string } => 'file' in item);
+
+      let resolvedItems: Array<{ component: string; variant: string }> = [];
+      if (fileItems.length > 0 && nonce) {
+        const resolvedFilePath = path.join(
+          os.tmpdir(),
+          `happo-resolved-skip-${nonce}.json`,
+        );
+        try {
+          const content = fs.readFileSync(resolvedFilePath, 'utf8');
+          const lines = content.trim().split('\n').filter(Boolean);
+          const parsed = lines.map(
+            (line) => JSON.parse(line) as { component: string; variant: string },
+          );
+          // Deduplicate
+          const seen = new Set<string>();
+          resolvedItems = parsed.filter((item) => {
+            const key = `${item.component}\0${item.variant}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+          });
+          fs.unlinkSync(resolvedFilePath);
+        } catch {
+          // No resolved file — file items can't be borrowed from baseline
+        }
+      }
+
+      body.skip = [
+        ...componentItems,
+        ...resolvedItems,
+      ] as Array<Example>;
     } catch (e) {
       logger.error('Error when parsing --skip', skipJSON);
       throw e;
@@ -249,6 +284,16 @@ export default async function runWithWrapper(
     await fs.promises.writeFile(skipFilePath, skipJSON, 'utf8');
   }
 
+  // Create a path for recording resolved skip items (file items → component items).
+  // Keyed by nonce so the finalize command can find it on the same machine.
+  const hasFileItems =
+    skipJSON !== undefined &&
+    parseSkip(skipJSON).some((item) => 'file' in item);
+  const resolvedSkipFilePath =
+    hasFileItems && environment.nonce
+      ? path.join(os.tmpdir(), `happo-resolved-skip-${environment.nonce}.json`)
+      : undefined;
+
   try {
     const exitCode = await new Promise<number>((resolve, reject) => {
       const childEnv: Record<string, string | undefined> = {
@@ -261,6 +306,10 @@ export default async function runWithWrapper(
 
       if (skipFilePath) {
         childEnv.HAPPO_SKIP_FILE = skipFilePath;
+      }
+
+      if (resolvedSkipFilePath) {
+        childEnv.HAPPO_RESOLVED_SKIP_FILE = resolvedSkipFilePath;
       }
 
       const child = spawn(dashdashCommandParts[0]!, dashdashCommandParts.slice(1), {
@@ -310,6 +359,11 @@ export default async function runWithWrapper(
     if (skipFilePath) {
       await fs.promises.unlink(skipFilePath).catch(() => {
         // Ignore errors — the file may already be gone.
+      });
+    }
+    if (resolvedSkipFilePath) {
+      await fs.promises.unlink(resolvedSkipFilePath).catch(() => {
+        // Ignore errors — finalize may have already cleaned it up.
       });
     }
   }

--- a/src/isomorphic/__tests__/parseSkip.test.ts
+++ b/src/isomorphic/__tests__/parseSkip.test.ts
@@ -14,40 +14,40 @@ describe('validateSkip', () => {
     assert.deepStrictEqual(result, [{ component: 'Button' }]);
   });
 
-  it('accepts storyFile items', () => {
+  it('accepts file items', () => {
     const result = validateSkip(
-      JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+      JSON.stringify([{ file: './src/Button.stories.tsx' }]),
     );
-    assert.deepStrictEqual(result, [{ storyFile: './src/Button.stories.tsx' }]);
+    assert.deepStrictEqual(result, [{ file: './src/Button.stories.tsx' }]);
   });
 
-  it('rejects storyFile items with variant', () => {
+  it('rejects file items with variant', () => {
     assert.throws(
       () =>
         validateSkip(
-          JSON.stringify([{ storyFile: './src/Button.stories.tsx', variant: 'Primary' }]),
+          JSON.stringify([{ file: './src/Button.stories.tsx', variant: 'Primary' }]),
         ),
       TypeError,
     );
   });
 
-  it('accepts a mix of component and storyFile items', () => {
+  it('accepts a mix of component and file items', () => {
     const items = [
       { component: 'Button', variant: 'Primary' },
-      { storyFile: './src/Input.stories.tsx' },
+      { file: './src/Input.stories.tsx' },
     ];
     const result = validateSkip(JSON.stringify(items));
     assert.deepStrictEqual(result, items);
   });
 
-  it('rejects items with both component and storyFile', () => {
+  it('rejects items with both component and file', () => {
     assert.throws(
-      () => validateSkip(JSON.stringify([{ component: 'Button', storyFile: './foo.tsx' }])),
+      () => validateSkip(JSON.stringify([{ component: 'Button', file: './foo.tsx' }])),
       TypeError,
     );
   });
 
-  it('rejects items with neither component nor storyFile', () => {
+  it('rejects items with neither component nor file', () => {
     assert.throws(
       () => validateSkip(JSON.stringify([{ variant: 'Primary' }])),
       TypeError,
@@ -68,7 +68,7 @@ describe('validateSkip', () => {
       assert.fail('expected an error');
     } catch (e) {
       assert.ok(e instanceof TypeError);
-      assert.match(e.message, /storyFile/);
+      assert.match(e.message, /file/);
       assert.match(e.message, /component/);
     }
   });
@@ -86,7 +86,7 @@ describe('parseSkip', () => {
   it('returns parsed items for valid JSON', () => {
     const items = [
       { component: 'Button' },
-      { storyFile: './src/Input.stories.tsx' },
+      { file: './src/Input.stories.tsx' },
     ];
     assert.deepStrictEqual(parseSkip(JSON.stringify(items)), items);
   });
@@ -103,16 +103,16 @@ describe('toSkipSet', () => {
     assert.ok(!isInSkipSet(set, 'Button', 'Secondary'));
   });
 
-  it('ignores storyFile items', () => {
-    const set = toSkipSet([{ storyFile: './src/Button.stories.tsx' }]);
+  it('ignores file items', () => {
+    const set = toSkipSet([{ file: './src/Button.stories.tsx' }]);
     // No component-based entries, so nothing is skipped
     assert.ok(!isInSkipSet(set, 'Button', 'Primary'));
   });
 
-  it('handles a mix of component and storyFile items', () => {
+  it('handles a mix of component and file items', () => {
     const set = toSkipSet([
       { component: 'Card' },
-      { storyFile: './src/Button.stories.tsx' },
+      { file: './src/Button.stories.tsx' },
     ]);
     assert.ok(isInSkipSet(set, 'Card', 'Default'));
     assert.ok(!isInSkipSet(set, 'Button', 'Primary'));

--- a/src/isomorphic/parseSkip.ts
+++ b/src/isomorphic/parseSkip.ts
@@ -11,9 +11,9 @@ function isSkipItem(item: unknown): item is SkipItem {
   if (typeof item !== 'object' || item === null) return false;
   const record = item as Record<string, unknown>;
   const hasComponent = typeof record['component'] === 'string';
-  const hasStoryFile = typeof record['storyFile'] === 'string';
-  if (hasComponent && hasStoryFile) return false;
-  if (hasStoryFile) return record['variant'] === undefined;
+  const hasFile = typeof record['file'] === 'string';
+  if (hasComponent && hasFile) return false;
+  if (hasFile) return record['variant'] === undefined;
   if (hasComponent) return record['variant'] === undefined || typeof record['variant'] === 'string';
   return false;
 }
@@ -26,7 +26,7 @@ export function validateSkip(json: string): Array<SkipItem> {
   const parsed: unknown = JSON.parse(json);
   if (!Array.isArray(parsed) || !parsed.every(isSkipItem)) {
     throw new TypeError(
-      '--skip must be a JSON array of {component, variant?} or {storyFile} objects',
+      '--skip must be a JSON array of {component, variant?} or {file} objects',
     );
   }
   return parsed;
@@ -47,7 +47,7 @@ export function parseSkip(json?: string): Array<SkipItem> {
 
 /**
  * Converts an array of SkipItems into a SkipSet for efficient lookups.
- * Items with a `storyFile` key (unresolved) are silently ignored.
+ * Items with a `file` key (unresolved) are silently ignored.
  */
 export function toSkipSet(items: Array<SkipItem>): SkipSet {
   const componentOnly = new Set<string>();

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -81,4 +81,4 @@ export type Logger = Pick<Console, 'log' | 'error'>;
 
 export type SkipItem =
   | { component: string; variant?: string }
-  | { storyFile: string };
+  | { file: string };

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -112,7 +112,12 @@ export const test: TestType<
     const rawSkipped = skippedFilePath
       ? fs.readFileSync(skippedFilePath, 'utf8')
       : undefined;
-    const skipSet = toSkipSet(parseSkip(rawSkipped));
+    const parsedSkip = parseSkip(rawSkipped);
+    const skipSet = toSkipSet(parsedSkip);
+    const fileItems = parsedSkip
+      .filter((item): item is { file: string } => 'file' in item)
+      .map((item) => ({ file: path.resolve(item.file) }));
+    const resolvedSkipFilePath = process.env.HAPPO_RESOLVED_SKIP_FILE;
 
     const happoScreenshot: ScreenshotFunction = async (
       handleOrLocator,
@@ -137,6 +142,22 @@ export const test: TestType<
       }
       if (!variant) {
         throw new Error('Missing `variant`');
+      }
+
+      const testFile = base.info().file;
+      if (fileItems.some((item) => item.file === testFile)) {
+        if (resolvedSkipFilePath) {
+          try {
+            fs.appendFileSync(
+              resolvedSkipFilePath,
+              JSON.stringify({ component, variant }) + '\n',
+              'utf8',
+            );
+          } catch {
+            // Ignore write errors
+          }
+        }
+        return;
       }
 
       if (isInSkipSet(skipSet, component, variant)) {

--- a/src/storybook/__tests__/resolveStoryFileItems.test.ts
+++ b/src/storybook/__tests__/resolveStoryFileItems.test.ts
@@ -37,17 +37,17 @@ describe('resolveStoryFileItems', () => {
     assert.deepStrictEqual(result, [{ component: 'Button', variant: 'Primary' }]);
   });
 
-  it('resolves storyFile to component name', () => {
+  it('resolves file to component name', () => {
     const result = resolveStoryFileItems(
-      [{ storyFile: './src/Button.stories.tsx' }],
+      [{ file: './src/Button.stories.tsx' }],
       entries,
     );
     assert.deepStrictEqual(result, [{ component: 'Button' }]);
   });
 
-  it('resolves storyFile without leading ./', () => {
+  it('resolves file without leading ./', () => {
     const result = resolveStoryFileItems(
-      [{ storyFile: 'src/Input.stories.tsx' }],
+      [{ file: 'src/Input.stories.tsx' }],
       entries,
     );
     assert.deepStrictEqual(result, [{ component: 'Input' }]);
@@ -56,16 +56,16 @@ describe('resolveStoryFileItems', () => {
   it('returns one entry per unique component title, not per story', () => {
     // Button has two stories but one title — should produce one resolved item
     const result = resolveStoryFileItems(
-      [{ storyFile: 'src/Button.stories.tsx' }],
+      [{ file: 'src/Button.stories.tsx' }],
       entries,
     );
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0]?.component, 'Button');
   });
 
-  it('handles a mix of component and storyFile items', () => {
+  it('handles a mix of component and file items', () => {
     const result = resolveStoryFileItems(
-      [{ component: 'Card', variant: 'Default' }, { storyFile: 'src/Input.stories.tsx' }],
+      [{ component: 'Card', variant: 'Default' }, { file: 'src/Input.stories.tsx' }],
       entries,
     );
     assert.deepStrictEqual(result, [
@@ -74,11 +74,11 @@ describe('resolveStoryFileItems', () => {
     ]);
   });
 
-  it('warns and skips storyFile items not found in the index', () => {
+  it('warns and skips file items not found in the index', () => {
     const warnMock = mock.method(console, 'warn', () => {});
     try {
       const result = resolveStoryFileItems(
-        [{ storyFile: 'src/NotFound.stories.tsx' }],
+        [{ file: 'src/NotFound.stories.tsx' }],
         entries,
       );
       assert.deepStrictEqual(result, []);
@@ -97,7 +97,7 @@ describe('resolveStoryFileItems', () => {
   it('returns empty array when entries are empty', () => {
     const warnMock = mock.method(console, 'warn', () => {});
     try {
-      const result = resolveStoryFileItems([{ storyFile: 'src/Button.stories.tsx' }], {});
+      const result = resolveStoryFileItems([{ file: 'src/Button.stories.tsx' }], {});
       assert.deepStrictEqual(result, []);
       assert.strictEqual(warnMock.mock.callCount(), 1);
     } finally {

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -115,7 +115,7 @@ export default async function buildStorybookPackage({
   try {
     const iframeContent = await fs.promises.readFile(iframePath, 'utf8');
 
-    // Read index.json once to compute story count and resolve storyFile items.
+    // Read index.json once to compute story count and resolve file items.
     let estimatedSnapsCount: number | undefined;
     let resolvedSkip: Array<{ component: string; variant?: string }> | undefined;
 

--- a/src/storybook/resolveStoryFileItems.ts
+++ b/src/storybook/resolveStoryFileItems.ts
@@ -10,12 +10,12 @@ export interface StorybookIndexEntry {
 }
 
 /**
- * Resolves `storyFile` skip items to component-based skip items using the
+ * Resolves `file` skip items to component-based skip items using the
  * Storybook `index.json` entries. Items that already have a `component` are
  * passed through unchanged.
  *
  * Path matching is done by normalising both the `importPath` from the index
- * and the user-supplied `storyFile` (stripping a leading `./`), with an
+ * and the user-supplied `file` (stripping a leading `./`), with an
  * absolute-path fallback via `path.resolve`.
  */
 export default function resolveStoryFileItems(
@@ -42,12 +42,12 @@ export default function resolveStoryFileItems(
       continue;
     }
 
-    const normalizedFile = normalizeImportPath(item.storyFile);
+    const normalizedFile = normalizeImportPath(item.file);
     let components = fileToComponents.get(normalizedFile);
 
     if (!components) {
       // Fall back to absolute path comparison
-      const resolvedFile = path.resolve(item.storyFile);
+      const resolvedFile = path.resolve(item.file);
       for (const [normalizedImport, titles] of fileToComponents) {
         if (path.resolve(normalizedImport) === resolvedFile) {
           components = titles;
@@ -62,7 +62,7 @@ export default function resolveStoryFileItems(
       }
     } else {
       console.warn(
-        `[HAPPO] Could not find any stories for storyFile '${item.storyFile}' in the Storybook index`,
+        `[HAPPO] Could not find any stories for file '${item.file}' in the Storybook index`,
       );
     }
   }


### PR DESCRIPTION
## Summary

- Renames the `storyFile` field in `SkipItem` to `file` across the entire codebase
- Extends `--skip` `file` item support to Cypress and Playwright integrations: screenshots taken inside test files matching a `file` item are skipped
- Cypress: `happoGetIntegrationConfig` resolves `file` paths to absolute so the browser can compare against `Cypress.spec.absolute`; new `happoRecordResolvedSkip` task records skipped `{component, variant}` pairs to a temp file
- Playwright: fixture checks `test.info().file` against resolved `file` paths; matching screenshots are recorded to the same temp file
- E2E finalize (`finalizeAll`): reads the nonce-keyed resolved-skip file (`happo-resolved-skip-<nonce>.json` in tmpdir) to replace `file` items with the collected component/variant pairs before sending to the API

## Test plan

- [ ] All unit tests pass (`pnpm test`)
- [ ] TypeScript type-check passes (`pnpm build:types`)
- [ ] Manual Cypress/Playwright test with `--skip '[{"file":"./src/foo.cy.ts"}]'` skips the expected screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)