### PR TITLE
Add --only CLI flag for Storybook integration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           happo-api-key: ${{ secrets.HAPPO_API_KEY }}
           happo-api-secret: ${{ secrets.HAPPO_API_SECRET }}
-          projects: 'cypress,storybook-v9,storybook-v10,storybook-skipped,playwright,playwright-nonce,custom,pages'
+          projects: 'cypress,storybook-v9,storybook-v10,storybook-skipped,storybook-only,playwright,playwright-nonce,custom,pages'
 
   cypress:
     runs-on: ubuntu-latest
@@ -94,6 +94,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-env
       - run: pnpm test:storybook:skipped
+
+  storybook-only:
+    runs-on: ubuntu-latest
+    name: Storybook (only examples)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-env
+      - run: pnpm test:storybook:only
 
   playwright:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test:playwright:nonce": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE e2e -- playwright test && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE finalize",
     "test:storybook": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts",
     "test:storybook:skipped": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-skipped --skip \"$(node ./scripts/getSkip.ts)\"",
+    "test:storybook:only": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-only --only \"$(node ./scripts/getOnly.ts)\"",
     "test:pages": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.pages.config.ts",
     "tsc": "tsc --build tsconfig.json"
   },

--- a/scripts/getOnly.ts
+++ b/scripts/getOnly.ts
@@ -1,19 +1,10 @@
 /**
- * Outputs an --only JSON argument with two items, cycling through a set of
- * examples based on the current day of the week so that different examples
- * are included on each day.
- *
- * - One item uses the `component` form to include all variants of a component.
- * - One item uses the `storyFile` form to include all stories in a file.
+ * Outputs an --only JSON argument with a single storyFile item, cycling
+ * through the available story files based on the current day of the week.
  *
  * Usage:
  *   node scripts/getOnly.ts
  */
-
-const componentExamples = [
-  { component: 'Stories' },
-  { component: 'Interactive' },
-];
 
 const storyFileExamples = [
   { storyFile: './src/storybook/__tests__/storybook-app/Interactive.stories.ts' },
@@ -21,7 +12,6 @@ const storyFileExamples = [
 ];
 
 const day = new Date().getDay(); // 0 (Sun) – 6 (Sat)
-const componentItem = componentExamples[day % componentExamples.length];
 const storyFileItem = storyFileExamples[day % storyFileExamples.length];
 
-process.stdout.write(JSON.stringify([componentItem, storyFileItem]));
+process.stdout.write(JSON.stringify([storyFileItem]));

--- a/scripts/getOnly.ts
+++ b/scripts/getOnly.ts
@@ -1,0 +1,27 @@
+/**
+ * Outputs an --only JSON argument with two items, cycling through a set of
+ * examples based on the current day of the week so that different examples
+ * are included on each day.
+ *
+ * - One item uses the `component` form to include all variants of a component.
+ * - One item uses the `storyFile` form to include all stories in a file.
+ *
+ * Usage:
+ *   node scripts/getOnly.ts
+ */
+
+const componentExamples = [
+  { component: 'Stories' },
+  { component: 'Interactive' },
+];
+
+const storyFileExamples = [
+  { storyFile: './src/storybook/__tests__/storybook-app/Interactive.stories.ts' },
+  { storyFile: './src/storybook/__tests__/storybook-app/Story.stories.ts' },
+];
+
+const day = new Date().getDay(); // 0 (Sun) – 6 (Sat)
+const componentItem = componentExamples[day % componentExamples.length];
+const storyFileItem = storyFileExamples[day % storyFileExamples.length];
+
+process.stdout.write(JSON.stringify([componentItem, storyFileItem]));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -416,6 +416,20 @@ async function handleDefaultCommand(
         process.exitCode = 1;
         return;
       }
+
+      // Find a baseline to borrow the excluded stories from, unless --skip
+      // already resolved one.
+      if (!baselineSha) {
+        const findBaselineReport = (
+          await import('../network/findBaselineReport.ts')
+        ).default;
+        baselineSha = await findBaselineReport(environment, config, logger);
+        if (!baselineSha) {
+          logger.log(
+            '[HAPPO] No baseline report found for --only run. Excluded stories will not be borrowed from a baseline.',
+          );
+        }
+      }
     }
 
     // Prepare the snap requests for the job. This includes bundling static
@@ -434,6 +448,18 @@ async function handleDefaultCommand(
       const extendsRequestId = await createExtendsReportSnapRequest(
         baselineSha,
         resolvedSkip ?? skip,
+        config,
+      );
+      allSnapRequestIds = [...snapRequestIds, extendsRequestId];
+    } else if (only && baselineSha && resolvedSkip && resolvedSkip.length > 0) {
+      const createExtendsReportSnapRequest = (
+        await import('../network/createExtendsReportSnapRequest.ts')
+      ).default;
+      // resolvedSkip here is the complement of the only list — all components
+      // that were excluded and should be borrowed from the baseline.
+      const extendsRequestId = await createExtendsReportSnapRequest(
+        baselineSha,
+        resolvedSkip,
         config,
       );
       allSnapRequestIds = [...snapRequestIds, extendsRequestId];

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,8 +5,9 @@ import type { ConfigWithDefaults } from '../config/index.ts';
 import { findConfigFile, loadConfigFile } from '../config/loadConfig.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
 import resolveEnvironment from '../environment/index.ts';
+import { validateOnly } from '../isomorphic/parseOnly.ts';
 import { validateSkip } from '../isomorphic/parseSkip.ts';
-import type { Logger, SkipItem } from '../isomorphic/types.ts';
+import type { Logger, OnlyItem, SkipItem } from '../isomorphic/types.ts';
 import type { ParsedCLIArgs } from './parseOptions.ts';
 import { parseOptions } from './parseOptions.ts';
 import type { Reporter } from './telemetry.ts';
@@ -129,6 +130,7 @@ Options:
   --nonce <nonce>       Nonce to use for Cypress/Playwright comparison
   --githubToken <token> GitHub token to use for posting Happo statuses as comments. Use in combination with the \`githubApiUrl\` configuration option. (default: auto-detected from environment)
   --skip <json> JSON array of {component, variant} objects to skip in this run and borrow from the nearest baseline report instead
+  --only <json> JSON array of {component} or {storyFile} objects to include in this run (all other stories are skipped); only supported for the Storybook integration
 
 Flake command options:
   --allProjects         List flakes across all projects (default: current project)
@@ -158,6 +160,7 @@ Examples:
   happo -- playwright test
 
   happo --skip '[{"component":"Button","variant":"Primary"}]'
+  happo --only '[{"component":"Button"},{"storyFile":"./src/Input.stories.tsx"}]'
 
   happo finalize
   happo finalize --nonce my-unique-nonce
@@ -391,10 +394,34 @@ async function handleDefaultCommand(
       }
     }
 
+    // When --only is set, validate and apply it (storybook only).
+    let only: Array<OnlyItem> | undefined;
+
+    if (environment.only) {
+      if (config.integration.type !== 'storybook') {
+        logger.error(
+          `[HAPPO] --only is not supported for integration type '${config.integration.type}'. Supported types: storybook`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      try {
+        only = validateOnly(environment.only);
+      } catch (e) {
+        logger.error(
+          '[HAPPO] Invalid --only:',
+          e instanceof Error ? e.message : String(e),
+        );
+        process.exitCode = 1;
+        return;
+      }
+    }
+
     // Prepare the snap requests for the job. This includes bundling static
     // assets and uploading them. Only pass the skip list when we have a
     // baseline to borrow the skipped examples from.
-    const { snapRequestIds, resolvedSkip } = await prepareSnapRequests(config, skip);
+    const { snapRequestIds, resolvedSkip } = await prepareSnapRequests(config, skip, only);
 
     let allSnapRequestIds = snapRequestIds;
 

--- a/src/cli/parseOptions.ts
+++ b/src/cli/parseOptions.ts
@@ -104,6 +104,10 @@ export const parseOptions = {
   skip: {
     type: 'string',
   },
+
+  only: {
+    type: 'string',
+  },
 } as const;
 
 export type ParsedCLIArgs = ReturnType<

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -45,6 +45,7 @@ export interface EnvironmentResult {
   githubToken: string | undefined;
   ci: boolean;
   skip: string | undefined;
+  only: string | undefined;
 }
 
 const envKeys: ReadonlyArray<string> = [
@@ -641,6 +642,7 @@ export default async function resolveEnvironment(
     githubToken: cliArgs.githubToken,
     ci: !!env.CI,
     skip: cliArgs.skip,
+    only: cliArgs.only,
   };
 
   if (debugMode) {

--- a/src/isomorphic/__tests__/parseOnly.test.ts
+++ b/src/isomorphic/__tests__/parseOnly.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { parseOnly, validateOnly } from '../parseOnly.ts';
+
+describe('validateOnly', () => {
+  it('accepts component items', () => {
+    const result = validateOnly(JSON.stringify([{ component: 'Button' }]));
+    assert.deepStrictEqual(result, [{ component: 'Button' }]);
+  });
+
+  it('rejects component items with variant', () => {
+    assert.throws(
+      () =>
+        validateOnly(
+          JSON.stringify([{ component: 'Button', variant: 'Primary' }]),
+        ),
+      TypeError,
+    );
+  });
+
+  it('accepts storyFile items', () => {
+    const result = validateOnly(
+      JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+    );
+    assert.deepStrictEqual(result, [{ storyFile: './src/Button.stories.tsx' }]);
+  });
+
+  it('rejects storyFile items with variant', () => {
+    assert.throws(
+      () =>
+        validateOnly(
+          JSON.stringify([{ storyFile: './src/Button.stories.tsx', variant: 'Primary' }]),
+        ),
+      TypeError,
+    );
+  });
+
+  it('accepts a mix of component and storyFile items', () => {
+    const items = [
+      { component: 'Button' },
+      { storyFile: './src/Input.stories.tsx' },
+    ];
+    const result = validateOnly(JSON.stringify(items));
+    assert.deepStrictEqual(result, items);
+  });
+
+  it('rejects items with both component and storyFile', () => {
+    assert.throws(
+      () => validateOnly(JSON.stringify([{ component: 'Button', storyFile: './foo.tsx' }])),
+      TypeError,
+    );
+  });
+
+  it('rejects items with neither component nor storyFile', () => {
+    assert.throws(
+      () => validateOnly(JSON.stringify([{ variant: 'Primary' }])),
+      TypeError,
+    );
+  });
+
+  it('rejects non-array JSON', () => {
+    assert.throws(() => validateOnly(JSON.stringify({ component: 'Button' })), TypeError);
+  });
+
+  it('throws on invalid JSON', () => {
+    assert.throws(() => validateOnly('not json'), SyntaxError);
+  });
+
+  it('error message mentions variant not supported', () => {
+    try {
+      validateOnly(JSON.stringify([{ invalid: true }]));
+      assert.fail('expected an error');
+    } catch (e) {
+      assert.ok(e instanceof TypeError);
+      assert.match(e.message, /variant/);
+    }
+  });
+});
+
+describe('parseOnly', () => {
+  it('returns empty array when called with no argument', () => {
+    assert.deepStrictEqual(parseOnly(), []);
+  });
+
+  it('returns empty array for invalid JSON', () => {
+    assert.deepStrictEqual(parseOnly('not json'), []);
+  });
+
+  it('returns parsed items for valid JSON', () => {
+    const items = [
+      { component: 'Button' },
+      { storyFile: './src/Input.stories.tsx' },
+    ];
+    assert.deepStrictEqual(parseOnly(JSON.stringify(items)), items);
+  });
+});

--- a/src/isomorphic/parseOnly.ts
+++ b/src/isomorphic/parseOnly.ts
@@ -1,0 +1,42 @@
+import type { OnlyItem } from './types.ts';
+
+function isOnlyItem(item: unknown): item is OnlyItem {
+  if (typeof item !== 'object' || item === null) return false;
+  const record = item as Record<string, unknown>;
+  const hasComponent = typeof record['component'] === 'string';
+  const hasStoryFile = typeof record['storyFile'] === 'string';
+  if (hasComponent && hasStoryFile) return false;
+  if (hasStoryFile) return record['variant'] === undefined;
+  if (hasComponent) return record['variant'] === undefined;
+  return false;
+}
+
+/**
+ * Parses and validates a JSON string, returning an array of OnlyItems.
+ * Throws a TypeError if the JSON is invalid or not an array of OnlyItems.
+ *
+ * Note: `variant` is not supported in `--only` items because variants cannot
+ * be resolved statically from the Storybook built files.
+ */
+export function validateOnly(json: string): Array<OnlyItem> {
+  const parsed: unknown = JSON.parse(json);
+  if (!Array.isArray(parsed) || !parsed.every(isOnlyItem)) {
+    throw new TypeError(
+      '--only must be a JSON array of {component} or {storyFile} objects (variant is not supported)',
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parses a JSON string into an array of OnlyItems. Returns an empty array on
+ * any parse error or if the value is not a valid array of OnlyItems.
+ */
+export function parseOnly(json?: string): Array<OnlyItem> {
+  if (!json) return [];
+  try {
+    return validateOnly(json);
+  } catch {
+    return [];
+  }
+}

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -82,3 +82,7 @@ export type Logger = Pick<Console, 'log' | 'error'>;
 export type SkipItem =
   | { component: string; variant?: string }
   | { storyFile: string };
+
+export type OnlyItem =
+  | { component: string }
+  | { storyFile: string };

--- a/src/network/__tests__/cancelJob.test.ts
+++ b/src/network/__tests__/cancelJob.test.ts
@@ -62,6 +62,7 @@ beforeEach(async () => {
     githubToken: 'test-token',
     ci: false,
     skip: undefined,
+    only: undefined,
   };
 
   makeHappoAPIRequestImpl = async () => {

--- a/src/network/__tests__/createAsyncComparison.test.ts
+++ b/src/network/__tests__/createAsyncComparison.test.ts
@@ -70,6 +70,7 @@ beforeEach(async () => {
     githubToken: undefined,
     debugMode: false,
     skip: undefined,
+    only: undefined,
   };
 
   makeHappoAPIRequestMock.mock.resetCalls();

--- a/src/network/__tests__/findBaselineReport.test.ts
+++ b/src/network/__tests__/findBaselineReport.test.ts
@@ -58,6 +58,7 @@ beforeEach(async () => {
     githubToken: undefined,
     ci: false,
     skip: undefined,
+    only: undefined,
   };
 
   makeHappoAPIRequestImpl = async () => ({ sha: 'baseline-sha-123' });

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -5,7 +5,7 @@ import type { ConfigWithDefaults } from '../config/index.ts';
 import RemoteBrowserTarget, {
   type ExecuteParams,
 } from '../config/RemoteBrowserTarget.ts';
-import type { SkipItem } from '../isomorphic/types.ts';
+import type { OnlyItem, SkipItem } from '../isomorphic/types.ts';
 import buildStorybookPackage from '../storybook/index.ts';
 import deterministicArchive from '../utils/deterministicArchive.ts';
 import Logger, { logTag } from '../utils/Logger.ts';
@@ -78,6 +78,7 @@ async function buildPackage(
   { integration }: ConfigWithDefaults,
   logger: Logger,
   skip?: Array<SkipItem>,
+  only?: Array<OnlyItem>,
 ): Promise<BuildPackageResult> {
   if (integration.type === 'custom') {
     const { rootDir, entryPoint, estimatedSnapsCount } = await integration.build();
@@ -99,6 +100,7 @@ async function buildPackage(
     const result = await buildStorybookPackage({
       ...integration,
       ...(skip === undefined ? {} : { skip }),
+      ...(only === undefined ? {} : { only }),
     });
     return result;
   }
@@ -126,8 +128,9 @@ async function preparePackage(
   config: ConfigWithDefaults,
   logger: Logger,
   skip?: Array<SkipItem>,
+  only?: Array<OnlyItem>,
 ): Promise<PreparePackageResult> {
-  const { packageDir, estimatedSnapsCount, resolvedSkip } = await buildPackage(config, logger, skip);
+  const { packageDir, estimatedSnapsCount, resolvedSkip } = await buildPackage(config, logger, skip, only);
 
   await validatePackage(packageDir);
 
@@ -159,12 +162,13 @@ export interface PrepareSnapRequestsResult {
 export default async function prepareSnapRequests(
   config: ConfigWithDefaults,
   skip?: Array<SkipItem>,
+  only?: Array<OnlyItem>,
 ): Promise<PrepareSnapRequestsResult> {
   const logger = new Logger();
   const prepareResult =
     config.integration.type === 'pages'
       ? null
-      : await preparePackage(config, logger, skip);
+      : await preparePackage(config, logger, skip, only);
 
   const targetNames = Object.keys(config.targets);
   const tl = targetNames.length;

--- a/src/storybook/__tests__/index.test.ts
+++ b/src/storybook/__tests__/index.test.ts
@@ -45,4 +45,29 @@ describe('happoStorybookPlugin', () => {
       assert.strictEqual(result.estimatedSnapsCount, 21);
     });
   });
+
+  describe('with --only', () => {
+    it('reduces estimatedSnapsCount to the matched component', async () => {
+      // Interactive has 2 stories (Demo + Interactive Throws Error)
+      const result = await happoStorybookPlugin({
+        usePrebuiltPackage: true,
+        only: [{ component: 'Interactive' }],
+      });
+      assert.strictEqual(result.estimatedSnapsCount, 2);
+    });
+
+    it('reduces estimatedSnapsCount when matching via storyFile', async () => {
+      // Story.stories.ts has 20 stories under the Stories component
+      const result = await happoStorybookPlugin({
+        usePrebuiltPackage: true,
+        only: [
+          {
+            storyFile:
+              './src/storybook/__tests__/storybook-app/Story.stories.ts',
+          },
+        ],
+      });
+      assert.strictEqual(result.estimatedSnapsCount, 20);
+    });
+  });
 });

--- a/src/storybook/browser/register.ts
+++ b/src/storybook/browser/register.ts
@@ -17,7 +17,7 @@ interface HappoTime {
 declare global {
   var happoTime: HappoTime | undefined;
   var happoSkipped: SkipItems | undefined;
-  var happoOnly: OnlyItems | undefined;
+  var happoOnly: OnlyItems | null | undefined;
   var __IS_HAPPO_RUN: boolean | undefined;
   var __STORYBOOK_CLIENT_API__:
     | {

--- a/src/storybook/browser/register.ts
+++ b/src/storybook/browser/register.ts
@@ -6,7 +6,7 @@ import type {
   NextExampleResult,
   WindowHappo,
 } from '../../isomorphic/types.ts';
-import type { SkipItems } from '../isomorphic/types.ts';
+import type { OnlyItems, SkipItems } from '../isomorphic/types.ts';
 import { SB_ROOT_ELEMENT_SELECTOR } from './constants.ts';
 
 interface HappoTime {
@@ -17,6 +17,7 @@ interface HappoTime {
 declare global {
   var happoTime: HappoTime | undefined;
   var happoSkipped: SkipItems | undefined;
+  var happoOnly: OnlyItems | undefined;
   var __IS_HAPPO_RUN: boolean | undefined;
   var __STORYBOOK_CLIENT_API__:
     | {
@@ -382,6 +383,14 @@ globalThis.happo.nextExample = async (): Promise<NextExampleResult | undefined> 
       )
     ) {
       console.log(`Skipping ${component}, ${variant} since it is in the skip list`);
+      return { component, variant, skipped: true };
+    }
+
+    if (
+      globalThis.happoOnly &&
+      !globalThis.happoOnly.some((item) => item.component === component)
+    ) {
+      console.log(`Skipping ${component}, ${variant} since it is not in the only list`);
       return { component, variant, skipped: true };
     }
 

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import type { StorybookIntegration } from '../config/index.ts';
 import { isInSkipSet, toSkipSet } from '../isomorphic/parseSkip.ts';
-import type { SkipItem } from '../isomorphic/types.ts';
+import type { OnlyItem, SkipItem } from '../isomorphic/types.ts';
 import getStorybookBuildCommandParts from './getStorybookBuildCommandParts.ts';
 import getStorybookVersionFromPackageJson from './getStorybookVersionFromPackageJson.ts';
 import resolveStoryFileItems, { type StorybookIndexEntry } from './resolveStoryFileItems.ts';
@@ -98,8 +98,10 @@ export default async function buildStorybookPackage({
   outputDir = '.out',
   usePrebuiltPackage = false,
   skip,
+  only,
 }: Omit<StorybookIntegration, 'type'> & {
   skip?: Array<SkipItem>;
+  only?: Array<OnlyItem>;
 }): Promise<BuildStorybookPackageResult> {
   if (!usePrebuiltPackage) {
     await buildStorybook({ configDir, staticDir, outputDir });
@@ -118,6 +120,7 @@ export default async function buildStorybookPackage({
     // Read index.json once to compute story count and resolve storyFile items.
     let estimatedSnapsCount: number | undefined;
     let resolvedSkip: Array<{ component: string; variant?: string }> | undefined;
+    let resolvedOnly: Array<{ component: string }> | undefined;
 
     const indexPath = path.join(outputDir, 'index.json');
     try {
@@ -140,6 +143,16 @@ export default async function buildStorybookPackage({
           (e) => !isInSkipSet(skipSet, e.title ?? '', e.name ?? ''),
         ).length;
       }
+
+      if (only !== undefined) {
+        resolvedOnly = resolveStoryFileItems(only as Array<SkipItem>, entries).map(
+          ({ component }) => ({ component }),
+        );
+        // Adjust the count so auto-chunking reflects only the stories that
+        // will actually be rendered (only matching examples need a chunk slot).
+        const onlyComponents = new Set(resolvedOnly.map((item) => item.component));
+        estimatedSnapsCount = storyEntries.filter((e) => onlyComponents.has(e.title ?? '')).length;
+      }
     } catch (error) {
       console.warn('[HAPPO] Failed to read Storybook index.json:', error);
       if (skip !== undefined) {
@@ -147,6 +160,10 @@ export default async function buildStorybookPackage({
         resolvedSkip = skip.filter(
           (item): item is { component: string; variant?: string } => 'component' in item,
         );
+      }
+      if (only !== undefined) {
+        resolvedOnly = only
+          .filter((item): item is { component: string } => 'component' in item);
       }
     }
 
@@ -158,6 +175,7 @@ export default async function buildStorybookPackage({
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <script type="text/javascript">window.__IS_HAPPO_RUN = true;</script>
             <script type="text/javascript">window.happoSkipped = ${JSON.stringify(resolvedSkip ?? []).replaceAll(/<\/script>/gi, String.raw`<\/script>`)};</script>
+            <script type="text/javascript">window.happoOnly = ${JSON.stringify(resolvedOnly ?? null).replaceAll(/<\/script>/gi, String.raw`<\/script>`)};</script>
           `,
       ),
     );

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -160,6 +160,16 @@ export default async function buildStorybookPackage({
           estimatedSnapsCount = storyEntries.filter((e) =>
             onlyComponents.has(e.title ?? ''),
           ).length;
+
+          // Compute the complement: all components NOT in the only list.
+          // These will be borrowed from the baseline via an extends-report.
+          const allComponents = new Set<string>();
+          for (const e of storyEntries) {
+            if (e.title) allComponents.add(e.title);
+          }
+          resolvedSkip = [...allComponents]
+            .filter((c) => !onlyComponents.has(c))
+            .map((component) => ({ component }));
         }
       }
     } catch (error) {

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -148,10 +148,19 @@ export default async function buildStorybookPackage({
         resolvedOnly = resolveStoryFileItems(only as Array<SkipItem>, entries).map(
           ({ component }) => ({ component }),
         );
-        // Adjust the count so auto-chunking reflects only the stories that
-        // will actually be rendered (only matching examples need a chunk slot).
-        const onlyComponents = new Set(resolvedOnly.map((item) => item.component));
-        estimatedSnapsCount = storyEntries.filter((e) => onlyComponents.has(e.title ?? '')).length;
+        if (resolvedOnly.length === 0) {
+          console.warn(
+            '[HAPPO] --only: no matching stories found in Storybook index. Generating a full report instead.',
+          );
+          resolvedOnly = undefined;
+        } else {
+          // Adjust the count so auto-chunking reflects only the stories that
+          // will actually be rendered (only matching examples need a chunk slot).
+          const onlyComponents = new Set(resolvedOnly.map((item) => item.component));
+          estimatedSnapsCount = storyEntries.filter((e) =>
+            onlyComponents.has(e.title ?? ''),
+          ).length;
+        }
       }
     } catch (error) {
       console.warn('[HAPPO] Failed to read Storybook index.json:', error);
@@ -162,8 +171,13 @@ export default async function buildStorybookPackage({
         );
       }
       if (only !== undefined) {
-        resolvedOnly = only
-          .filter((item): item is { component: string } => 'component' in item);
+        // Fall back to component-only items; if none remain, leave resolvedOnly
+        // undefined so the browser-side filtering is disabled and a full report
+        // is generated rather than an empty one.
+        const componentOnly = only.filter(
+          (item): item is { component: string } => 'component' in item,
+        );
+        resolvedOnly = componentOnly.length > 0 ? componentOnly : undefined;
       }
     }
 

--- a/src/storybook/isomorphic/types.ts
+++ b/src/storybook/isomorphic/types.ts
@@ -4,3 +4,9 @@ interface SkipItem {
 }
 
 export type SkipItems = Array<SkipItem>;
+
+interface OnlyItem {
+  component: string;
+}
+
+export type OnlyItems = Array<OnlyItem>;


### PR DESCRIPTION
## Summary

- Adds `--only` CLI flag as the inverse of `--skip`: renders only stories whose component or storyFile matches the given list, skipping everything else
- Supports `{component}` and `{storyFile}` items (no `variant` — can't be resolved statically from built Storybook files); validated at runtime to storybook integration only
- `storyFile` items are resolved to component names using the same `resolveStoryFileItems` logic as `--skip`
- `window.happoOnly` is injected into `iframe.html` and checked in the Storybook browser register before rendering each story
- `estimatedSnapsCount` is adjusted to reflect only the matching stories for accurate auto-chunking

## CI

- Added `storybook-only` job that runs `pnpm test:storybook:only`, using `scripts/getOnly.ts` to generate a rotating `--only` JSON with one `component` item and one `storyFile` item each day
- Added `storybook-only` to the orchestrate-happo projects list

## Test plan

- [ ] All existing unit tests pass (`pnpm test`)
- [ ] TypeScript compiles cleanly (`pnpm tsc`)
- [ ] `storybook-only` CI job passes with both `component` and `storyFile` items
- [ ] `--only` with a non-storybook integration prints a clear error and exits non-zero
- [ ] `--only` with invalid JSON prints a clear error and exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)