### PR TITLE
Add release-with-ease dev dependency and release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:storybook:skipped": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-skipped --skip \"$(node ./scripts/getSkip.ts)\"",
     "test:storybook:only": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-only --only \"$(node ./scripts/getOnly.ts)\"",
     "test:pages": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.pages.config.ts",
+    "release": "set -a && source .env && set +a && release-with-ease",
     "tsc": "tsc --build tsconfig.json"
   },
   "browserslist": {
@@ -135,6 +136,7 @@
     "react-error-boundary": "^6.0.0",
     "storybook": "^10.0.1",
     "typescript": "^6.0.2",
+    "release-with-ease": "^2.1.0",
     "typescript-eslint": "^8.57.2"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       react-error-boundary:
         specifier: ^6.0.0
         version: 6.1.1(react@19.2.5)
+      release-with-ease:
+        specifier: ^2.1.0
+        version: 2.1.0
       storybook:
         specifier: ^10.0.1
         version: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2327,6 +2330,10 @@ packages:
 
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
+    hasBin: true
+
+  release-with-ease@2.1.0:
+    resolution: {integrity: sha512-9AhNaAtSp8IR+XMZ3bymP4rPHEJpF/r2SCiQ6WJ3h0ob/v2allUiTVcUa8FRcRlPvh8beCSB4Pi3ajSp5IoRZg==}
     hasBin: true
 
   request-progress@3.0.0:
@@ -4859,6 +4866,8 @@ snapshots:
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
+
+  release-with-ease@2.1.0: {}
 
   request-progress@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `release-with-ease@^2.1.0` as a dev dependency
- Adds a `release` script that sources `.env` before invoking `release-with-ease`

## Test plan
- [ ] Run `pnpm release` to verify the release script works

🤖 Generated with [Claude Code](https://claude.com/claude-code)