### PR TITLE
Bring back --skippedExamples flag for the finalize command

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -865,7 +865,7 @@ describe('main', () => {
         assert(makeHappoAPIRequestMock.mock.callCount() > 0);
       });
 
-      it('sends skip in the finalize request body when --skip is set', async () => {
+      it('sends skip in the finalize request body when --skippedExamples is set', async () => {
         const skip = [
           { component: 'Button', variant: 'primary', target: 'chrome' },
         ];
@@ -880,7 +880,7 @@ describe('main', () => {
             'test-sha',
             '--nonce',
             'test-nonce',
-            '--skip',
+            '--skippedExamples',
             JSON.stringify(skip),
           ],
           logger,
@@ -897,7 +897,7 @@ describe('main', () => {
         );
       });
 
-      it('sends an empty skip array when --skip is not set', async () => {
+      it('sends an empty skip array when --skippedExamples is not set', async () => {
         await main(
           [
             'npx',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -132,6 +132,9 @@ Options:
   --skip <json> JSON array of {component, variant} objects to skip in this run and borrow from the nearest baseline report instead
   --only <json> JSON array of {component} or {storyFile} objects to include in this run (all other stories are skipped); only supported for the Storybook integration
 
+Finalize command options:
+  --skippedExamples <json> JSON array of {component, variant, target} objects to skip when finalizing; borrowed from the nearest baseline report
+
 Flake command options:
   --allProjects         List flakes across all projects (default: current project)
   --format <format>     Output format for flake command (default: "human", use "json" for raw output)
@@ -164,7 +167,7 @@ Examples:
 
   happo finalize
   happo finalize --nonce my-unique-nonce
-  happo finalize --skip '[{"component":"Button","variant":"primary","target":"chrome"}]'
+  happo finalize --skippedExamples '[{"component":"Button","variant":"primary","target":"chrome"}]'
 
   happo flake
   happo flake --allProjects
@@ -272,7 +275,10 @@ export async function main(
     }
 
     if (command === 'finalize') {
-      await handleFinalizeCommand(config, environment, logger);
+      const finalizeEnvironment = args.values.skippedExamples
+        ? { ...environment, skip: args.values.skippedExamples }
+        : environment;
+      await handleFinalizeCommand(config, finalizeEnvironment, logger);
       return;
     }
 

--- a/src/cli/parseOptions.ts
+++ b/src/cli/parseOptions.ts
@@ -105,6 +105,10 @@ export const parseOptions = {
     type: 'string',
   },
 
+  skippedExamples: {
+    type: 'string',
+  },
+
   only: {
     type: 'string',
   },


### PR DESCRIPTION
## Summary

- Restores `--skippedExamples` as the canonical flag for `happo finalize`, which was accidentally renamed to `--skip`
- `--skip` remains unchanged for the default command
- Updates help text and examples accordingly

## Test plan

- [ ] `pnpm test` passes (73 tests)
- [ ] `pnpm build:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)