### PR TITLE
Skip non-fetchable URL schemes in asset packager

### DIFF
--- a/src/e2e/__tests__/createAssetPackage.test.ts
+++ b/src/e2e/__tests__/createAssetPackage.test.ts
@@ -59,6 +59,54 @@ describe('createAssetPackage', () => {
     assert.equal(pkg.hash, expectedHash);
   });
 
+  it('skips non-fetchable URL schemes', async () => {
+    const pkg = await createAssetPackage(
+      [
+        {
+          url: '/sub%20folder/countries-bg.jpeg',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+        {
+          url: 'about:blank',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+        {
+          url: 'about:srcdoc',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+        {
+          url: 'blob:http://localhost/abc-123',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+        {
+          url: 'javascript:void(0)',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+        {
+          url: 'file:///etc/hosts',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+        {
+          url: 'chrome://version',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+        {
+          url: 'chrome-extension://abcdef/foo.png',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+        {
+          url: 'moz-extension://abcdef/foo.png',
+          baseUrl: `http://localhost:${serverInfo.port}`,
+        },
+      ],
+      { downloadAllAssets: true },
+    );
+
+    const zip = unzipSync(new Uint8Array(pkg.buffer));
+    const entries = Object.keys(zip).toSorted();
+    assert.deepEqual(entries, ['sub folder/countries-bg.jpeg']);
+  });
+
   it('includes external assets when downloadAllAssets is true', async () => {
     const pkg = await createAssetPackage(
       [

--- a/src/e2e/__tests__/createAssetPackage.test.ts
+++ b/src/e2e/__tests__/createAssetPackage.test.ts
@@ -61,7 +61,7 @@ describe('createAssetPackage', () => {
 
   it('skips non-fetchable URL schemes', async () => {
     const originalFetch = globalThis.fetch;
-    const fetchCalls: string[] = [];
+    const fetchCalls: Array<string> = [];
     globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
       const url =
         typeof input === 'string'

--- a/src/e2e/__tests__/createAssetPackage.test.ts
+++ b/src/e2e/__tests__/createAssetPackage.test.ts
@@ -60,51 +60,87 @@ describe('createAssetPackage', () => {
   });
 
   it('skips non-fetchable URL schemes', async () => {
-    const pkg = await createAssetPackage(
-      [
-        {
-          url: '/sub%20folder/countries-bg.jpeg',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-        {
-          url: 'about:blank',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-        {
-          url: 'about:srcdoc',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-        {
-          url: 'blob:http://localhost/abc-123',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-        {
-          url: 'javascript:void(0)',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-        {
-          url: 'file:///etc/hosts',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-        {
-          url: 'chrome://version',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-        {
-          url: 'chrome-extension://abcdef/foo.png',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-        {
-          url: 'moz-extension://abcdef/foo.png',
-          baseUrl: `http://localhost:${serverInfo.port}`,
-        },
-      ],
-      { downloadAllAssets: true },
-    );
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: string[] = [];
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      fetchCalls.push(url);
+      return originalFetch(input, init);
+    }) as typeof globalThis.fetch;
 
-    const zip = unzipSync(new Uint8Array(pkg.buffer));
-    const entries = Object.keys(zip).toSorted();
-    assert.deepEqual(entries, ['sub folder/countries-bg.jpeg']);
+    try {
+      const pkg = await createAssetPackage(
+        [
+          {
+            url: '/sub%20folder/countries-bg.jpeg',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'about:blank',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'About:Blank',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'about:srcdoc',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'blob:http://localhost/abc-123',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'javascript:void(0)',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'JAVASCRIPT:void(0)',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'file:///etc/hosts',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'chrome://version',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'chrome-extension://abcdef/foo.png',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+          {
+            url: 'moz-extension://abcdef/foo.png',
+            baseUrl: `http://localhost:${serverInfo.port}`,
+          },
+        ],
+        { downloadAllAssets: true },
+      );
+
+      const zip = unzipSync(new Uint8Array(pkg.buffer));
+      const entries = Object.keys(zip).toSorted();
+      assert.deepEqual(entries, ['sub folder/countries-bg.jpeg']);
+
+      // Blocked schemes must be filtered out before reaching the network
+      // layer — fetch should only ever be invoked for the valid local asset.
+      const validUrl = `http://localhost:${serverInfo.port}/sub%20folder/countries-bg.jpeg`;
+      const unexpected = fetchCalls.filter((u) => u !== validUrl);
+      assert.deepEqual(
+        unexpected,
+        [],
+        `Unexpected fetches for blocked schemes: ${unexpected.join(', ')}`,
+      );
+      assert.ok(fetchCalls.length >= 1, 'Valid asset should be fetched');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it('includes external assets when downloadAllAssets is true', async () => {

--- a/src/e2e/createAssetPackage.ts
+++ b/src/e2e/createAssetPackage.ts
@@ -68,7 +68,7 @@ export default async function createAssetPackage(
       const { url, baseUrl } = item;
 
       if (
-        /^(about|blob|javascript|file|chrome|chrome-extension|moz-extension):/.test(
+        /^(about|blob|javascript|file|chrome|chrome-extension|moz-extension):/i.test(
           url,
         )
       ) {

--- a/src/e2e/createAssetPackage.ts
+++ b/src/e2e/createAssetPackage.ts
@@ -66,6 +66,15 @@ export default async function createAssetPackage(
   await Promise.all(
     urls.map(async (item: AssetUrl) => {
       const { url, baseUrl } = item;
+
+      if (
+        /^(about|blob|javascript|file|chrome|chrome-extension|moz-extension):/.test(
+          url,
+        )
+      ) {
+        return;
+      }
+
       const isExternalUrl = /^https?:/.test(url);
       const isLocalhost = /\/\/(localhost|127\.0\.0\.1)(:|\/)/.test(url);
 


### PR DESCRIPTION
## Summary

- Skip URLs with non-fetchable schemes (`about:`, `blob:`, `javascript:`, `file:`, `chrome:`, `chrome-extension:`, `moz-extension:`) before attempting to download them in `createAssetPackage`.
- Previously these URLs (e.g. `about:blank` from iframes) would fall through to `fetchWithRetry` and log failed-fetch errors to the console.
- Added a test covering each of the blocked schemes.

Note: `data:` URLs are already filtered upstream in `takeDOMSnapshot.ts` and `findCSSAssetUrls.ts`, so they don't need handling here.

## Test plan

- [x] `pnpm test createAssetPackage` — new and existing tests pass