### PR TITLE
Support pnpm catalog: and workspace:* in Storybook version detection

### DIFF
--- a/src/storybook/__tests__/getStorybookVersionFromPackageJson.test.ts
+++ b/src/storybook/__tests__/getStorybookVersionFromPackageJson.test.ts
@@ -188,6 +188,43 @@ it("falls back to a direct node_modules read when the package's exports field hi
   assert.strictEqual(version, 9);
 });
 
+it('resolves version when the package is hoisted AND has an exports field that hides package.json', () => {
+  // Combination case flagged in review: the package is hoisted to a parent
+  // node_modules (so the direct projectRoot/node_modules/<pkg>/package.json
+  // fallback misses) AND its exports field does not expose ./package.json
+  // (so require.resolve('<pkg>/package.json') throws). The walk-up-from-entry
+  // tier must cover this.
+  tmpfs.mock({
+    'package.json': JSON.stringify({
+      name: 'workspace-root',
+      private: true,
+    }),
+    node_modules: {
+      storybook: {
+        'package.json': JSON.stringify({
+          name: 'storybook',
+          version: '9.4.0',
+          exports: { '.': './index.js' },
+        }),
+        'index.js': '',
+      },
+    },
+    packages: {
+      app: {
+        'package.json': JSON.stringify({
+          name: 'app',
+          devDependencies: { storybook: 'catalog:' },
+        }),
+      },
+    },
+  });
+
+  const version = getStorybookVersionFromPackageJson(
+    tmpfs.fullPath('packages/app/package.json'),
+  );
+  assert.strictEqual(version, 9);
+});
+
 it('throws a helpful error when the declared version is unparseable and the package cannot be resolved', () => {
   tmpfs.mock({
     'package.json': JSON.stringify({
@@ -198,6 +235,6 @@ it('throws a helpful error when the declared version is unparseable and the pack
 
   assert.throws(
     () => getStorybookVersionFromPackageJson(),
-    /Unable to determine Storybook major version/,
+    /Unable to determine installed version of storybook.*Ensure dependencies are installed/s,
   );
 });

--- a/src/storybook/__tests__/getStorybookVersionFromPackageJson.test.ts
+++ b/src/storybook/__tests__/getStorybookVersionFromPackageJson.test.ts
@@ -129,7 +129,7 @@ it('resolves version from node_modules when using workspace:* protocol', () => {
   assert.strictEqual(version, 9);
 });
 
-it('throws a helpful error when the declared version is unparseable and node_modules is missing', () => {
+it('throws a helpful error when the declared version is unparseable and the package cannot be resolved', () => {
   tmpfs.mock({
     'package.json': JSON.stringify({
       name: 'test',

--- a/src/storybook/__tests__/getStorybookVersionFromPackageJson.test.ts
+++ b/src/storybook/__tests__/getStorybookVersionFromPackageJson.test.ts
@@ -66,3 +66,79 @@ it('throws if storybook is not listed as a dependency', () => {
 
   assert.throws(() => getStorybookVersionFromPackageJson(), /not listed/);
 });
+
+it('resolves version from node_modules when using pnpm catalog:', () => {
+  tmpfs.mock({
+    'package.json': JSON.stringify({
+      name: 'test',
+      devDependencies: { storybook: 'catalog:' },
+    }),
+    node_modules: {
+      storybook: {
+        'package.json': JSON.stringify({
+          name: 'storybook',
+          version: '9.1.10',
+        }),
+      },
+    },
+  });
+
+  const version = getStorybookVersionFromPackageJson();
+  assert.strictEqual(version, 9);
+});
+
+it('resolves version from node_modules when using a named pnpm catalog', () => {
+  tmpfs.mock({
+    'package.json': JSON.stringify({
+      name: 'test',
+      devDependencies: { '@storybook/react': 'catalog:frontend' },
+    }),
+    node_modules: {
+      '@storybook': {
+        react: {
+          'package.json': JSON.stringify({
+            name: '@storybook/react',
+            version: '8.2.1',
+          }),
+        },
+      },
+    },
+  });
+
+  const version = getStorybookVersionFromPackageJson();
+  assert.strictEqual(version, 8);
+});
+
+it('resolves version from node_modules when using workspace:* protocol', () => {
+  tmpfs.mock({
+    'package.json': JSON.stringify({
+      name: 'test',
+      devDependencies: { storybook: 'workspace:*' },
+    }),
+    node_modules: {
+      storybook: {
+        'package.json': JSON.stringify({
+          name: 'storybook',
+          version: '9.0.0',
+        }),
+      },
+    },
+  });
+
+  const version = getStorybookVersionFromPackageJson();
+  assert.strictEqual(version, 9);
+});
+
+it('throws a helpful error when the declared version is unparseable and node_modules is missing', () => {
+  tmpfs.mock({
+    'package.json': JSON.stringify({
+      name: 'test',
+      devDependencies: { storybook: 'catalog:' },
+    }),
+  });
+
+  assert.throws(
+    () => getStorybookVersionFromPackageJson(),
+    /Unable to determine Storybook major version/,
+  );
+});

--- a/src/storybook/__tests__/getStorybookVersionFromPackageJson.test.ts
+++ b/src/storybook/__tests__/getStorybookVersionFromPackageJson.test.ts
@@ -129,6 +129,65 @@ it('resolves version from node_modules when using workspace:* protocol', () => {
   assert.strictEqual(version, 9);
 });
 
+it('resolves version from a parent node_modules (workspace hoisting / Yarn PnP-style walk-up)', () => {
+  // The "app" package is nested under packages/app and has no node_modules
+  // of its own — storybook is hoisted to the workspace root. Node's module
+  // resolution (via createRequire) walks up the tree to find it.
+  tmpfs.mock({
+    'package.json': JSON.stringify({
+      name: 'workspace-root',
+      private: true,
+    }),
+    node_modules: {
+      storybook: {
+        'package.json': JSON.stringify({
+          name: 'storybook',
+          version: '9.2.0',
+        }),
+      },
+    },
+    packages: {
+      app: {
+        'package.json': JSON.stringify({
+          name: 'app',
+          devDependencies: { storybook: 'catalog:' },
+        }),
+      },
+    },
+  });
+
+  const version = getStorybookVersionFromPackageJson(
+    tmpfs.fullPath('packages/app/package.json'),
+  );
+  assert.strictEqual(version, 9);
+});
+
+it("falls back to a direct node_modules read when the package's exports field hides package.json", () => {
+  // With an exports field that does not list "./package.json",
+  // require.resolve('storybook/package.json') throws
+  // ERR_PACKAGE_PATH_NOT_EXPORTED. The fallback should still read the file
+  // directly off disk.
+  tmpfs.mock({
+    'package.json': JSON.stringify({
+      name: 'test',
+      devDependencies: { storybook: 'catalog:' },
+    }),
+    node_modules: {
+      storybook: {
+        'package.json': JSON.stringify({
+          name: 'storybook',
+          version: '9.3.0',
+          exports: { '.': './index.js' },
+        }),
+        'index.js': '',
+      },
+    },
+  });
+
+  const version = getStorybookVersionFromPackageJson();
+  assert.strictEqual(version, 9);
+});
+
 it('throws a helpful error when the declared version is unparseable and the package cannot be resolved', () => {
   tmpfs.mock({
     'package.json': JSON.stringify({

--- a/src/storybook/getStorybookVersionFromPackageJson.ts
+++ b/src/storybook/getStorybookVersionFromPackageJson.ts
@@ -10,6 +10,33 @@ function readVersionFrom(filePath: string): string | undefined {
   }
 }
 
+function findPackageJsonForEntry(
+  entryPath: string,
+  pkg: string,
+): string | undefined {
+  // Walk up from a resolved entry file to the nearest package.json whose
+  // `name` matches `pkg`. Node's resolution always places the entry inside
+  // the package's own tree (even under pnpm's .pnpm virtual store or Yarn
+  // PnP's zipfs), so this reliably finds the correct root.
+  let dir = path.dirname(entryPath);
+  while (true) {
+    const candidate = path.join(dir, 'package.json');
+    try {
+      const parsed = JSON.parse(fs.readFileSync(candidate, 'utf8'));
+      if (parsed.name === pkg) {
+        return candidate;
+      }
+    } catch {
+      // not a readable package.json here; keep walking up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
+  }
+}
+
 function readInstalledVersion(
   pkg: string,
   projectRoot: string,
@@ -18,10 +45,13 @@ function readInstalledVersion(
   // itself understands: flat node_modules (npm/yarn classic), pnpm's symlinked
   // tree, hoisted packages in parent node_modules, and Yarn Plug'n'Play when
   // the process has PnP hooks installed.
+  const requireFromProject = createRequire(
+    path.join(projectRoot, 'package.json'),
+  );
+
+  // Tier 1: resolve `${pkg}/package.json` directly. The happy path for most
+  // packages regardless of layout.
   try {
-    const requireFromProject = createRequire(
-      path.join(projectRoot, 'package.json'),
-    );
     const version = readVersionFrom(
       requireFromProject.resolve(`${pkg}/package.json`),
     );
@@ -29,11 +59,32 @@ function readInstalledVersion(
       return version;
     }
   } catch {
-    // Fall through to the direct node_modules lookup below. Some packages
-    // have an `exports` field that does not expose `./package.json`, which
-    // makes require.resolve throw even when the file exists on disk.
+    // Packages whose `exports` field does not list `./package.json` make
+    // require.resolve throw `ERR_PACKAGE_PATH_NOT_EXPORTED` even when the
+    // file exists. Fall through.
   }
 
+  // Tier 2: resolve the package's main entry and walk up to its package.json.
+  // Covers the combination of a restrictive `exports` field and a hoisted
+  // install (parent node_modules, pnpm virtual store, Yarn PnP zipfs), where
+  // neither tier 1 nor the direct lookup below would work.
+  try {
+    const entryPath = requireFromProject.resolve(pkg);
+    const pkgJsonPath = findPackageJsonForEntry(entryPath, pkg);
+    if (pkgJsonPath) {
+      const version = readVersionFrom(pkgJsonPath);
+      if (version) {
+        return version;
+      }
+    }
+  } catch {
+    // Fall through to the direct node_modules lookup.
+  }
+
+  // Tier 3: read node_modules/<pkg>/package.json directly. Belt-and-suspenders
+  // for cases where the file exists on disk but require.resolve cannot reach
+  // it (e.g. both `.` and `./package.json` hidden behind a restrictive
+  // exports map).
   return readVersionFrom(
     path.join(projectRoot, 'node_modules', pkg, 'package.json'),
   );
@@ -71,16 +122,16 @@ export default function getStorybookVersionFromPackageJson(
   // pnpm catalogs ("catalog:", "catalog:foo"), workspace protocols
   // ("workspace:*"), and other non-semver specifiers ("link:", "file:", etc.).
   // Fall back to the version from the installed package in node_modules.
-  const installedVersion = readInstalledVersion(
-    storybookPackage,
-    path.dirname(packageJsonPath),
-  );
+  const projectRoot = path.dirname(packageJsonPath);
+  const installedVersion = readInstalledVersion(storybookPackage, projectRoot);
   const installedMatch = installedVersion?.match(/\d+/);
   if (installedMatch) {
     return Number.parseInt(installedMatch[0], 10);
   }
 
   throw new Error(
-    `Unable to determine Storybook major version (found "${declaredVersion}" for ${storybookPackage} in package.json and could not resolve the installed package)`,
+    `Unable to determine installed version of ${storybookPackage} (found "${declaredVersion}" in ${packageJsonPath}). ` +
+      `Tried resolving from ${projectRoot} and reading ${path.join(projectRoot, 'node_modules', storybookPackage, 'package.json')}. ` +
+      `Ensure dependencies are installed and that ${storybookPackage} is resolvable from that project root.`,
   );
 }

--- a/src/storybook/getStorybookVersionFromPackageJson.ts
+++ b/src/storybook/getStorybookVersionFromPackageJson.ts
@@ -1,19 +1,42 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
+
+function readVersionFrom(filePath: string): string | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')).version;
+  } catch {
+    return undefined;
+  }
+}
 
 function readInstalledVersion(
   pkg: string,
   projectRoot: string,
 ): string | undefined {
+  // Prefer Node's module resolution so we work with every layout that Node
+  // itself understands: flat node_modules (npm/yarn classic), pnpm's symlinked
+  // tree, hoisted packages in parent node_modules, and Yarn Plug'n'Play when
+  // the process has PnP hooks installed.
   try {
-    const installedPackageJson = fs.readFileSync(
-      path.join(projectRoot, 'node_modules', pkg, 'package.json'),
-      'utf8',
+    const requireFromProject = createRequire(
+      path.join(projectRoot, 'package.json'),
     );
-    return JSON.parse(installedPackageJson).version;
+    const version = readVersionFrom(
+      requireFromProject.resolve(`${pkg}/package.json`),
+    );
+    if (version) {
+      return version;
+    }
   } catch {
-    return undefined;
+    // Fall through to the direct node_modules lookup below. Some packages
+    // have an `exports` field that does not expose `./package.json`, which
+    // makes require.resolve throw even when the file exists on disk.
   }
+
+  return readVersionFrom(
+    path.join(projectRoot, 'node_modules', pkg, 'package.json'),
+  );
 }
 
 export default function getStorybookVersionFromPackageJson(
@@ -58,6 +81,6 @@ export default function getStorybookVersionFromPackageJson(
   }
 
   throw new Error(
-    `Unable to determine Storybook major version (found "${declaredVersion}" for ${storybookPackage} in package.json and no resolvable version in node_modules)`,
+    `Unable to determine Storybook major version (found "${declaredVersion}" for ${storybookPackage} in package.json and could not resolve the installed package)`,
   );
 }

--- a/src/storybook/getStorybookVersionFromPackageJson.ts
+++ b/src/storybook/getStorybookVersionFromPackageJson.ts
@@ -1,6 +1,21 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+function readInstalledVersion(
+  pkg: string,
+  projectRoot: string,
+): string | undefined {
+  try {
+    const installedPackageJson = fs.readFileSync(
+      path.join(projectRoot, 'node_modules', pkg, 'package.json'),
+      'utf8',
+    );
+    return JSON.parse(installedPackageJson).version;
+  } catch {
+    return undefined;
+  }
+}
+
 export default function getStorybookVersionFromPackageJson(
   packageJsonPath: string = path.join(process.cwd(), 'package.json'),
 ): number {
@@ -19,11 +34,30 @@ export default function getStorybookVersionFromPackageJson(
     '@storybook/vue',
   ].find((pkg) => combinedDependencies[pkg]);
 
-  if (storybookPackage) {
-    const storybookVersion = combinedDependencies[storybookPackage];
-    const majorVersion = Number.parseInt(storybookVersion.match(/\d+/)[0], 10);
-    return majorVersion;
-  } else {
+  if (!storybookPackage) {
     throw new Error('Storybook is not listed as a dependency in package.json');
   }
+
+  const declaredVersion: string = combinedDependencies[storybookPackage];
+  const declaredMatch = declaredVersion.match(/\d+/);
+  if (declaredMatch) {
+    return Number.parseInt(declaredMatch[0], 10);
+  }
+
+  // The declared dependency is not a plain semver range. This happens with
+  // pnpm catalogs ("catalog:", "catalog:foo"), workspace protocols
+  // ("workspace:*"), and other non-semver specifiers ("link:", "file:", etc.).
+  // Fall back to the version from the installed package in node_modules.
+  const installedVersion = readInstalledVersion(
+    storybookPackage,
+    path.dirname(packageJsonPath),
+  );
+  const installedMatch = installedVersion?.match(/\d+/);
+  if (installedMatch) {
+    return Number.parseInt(installedMatch[0], 10);
+  }
+
+  throw new Error(
+    `Unable to determine Storybook major version (found "${declaredVersion}" for ${storybookPackage} in package.json and no resolvable version in node_modules)`,
+  );
 }


### PR DESCRIPTION
## Summary

- Fix a crash in `getStorybookVersionFromPackageJson` when the `storybook` dependency uses non-semver specifiers such as pnpm's `"storybook": "catalog:"`. Previously `"catalog:".match(/\d+/)` returned `null`, and indexing `[0]` threw.
- When the declared version string contains no digits, fall back to reading the installed version from `node_modules/<pkg>/package.json`. This also covers `catalog:name`, `workspace:*`, `link:`, and `file:` specifiers.
- Replace the original `null`-deref path with a clear error that names the unparseable specifier, so users whose `node_modules` is missing get a diagnostic instead of a crash inside `.match()`.

## Why

Reported by a user who had to work around this with `usePrebuiltPackage` in order to consume Happo from a pnpm workspace using [pnpm catalogs](https://pnpm.io/catalogs). Native catalog support avoids that workaround.

## Test plan

- [x] `pnpm test getStorybookVersionFromPackageJson` — all 9 tests pass, including new cases for `catalog:`, named catalogs (`catalog:frontend`), `workspace:*`, and a missing-node_modules error case.
- [x] `pnpm build:types` passes.
- [x] `pnpm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)