### PR TITLE
Skip comparison for GitHub Actions push to default branch

### DIFF
--- a/src/environment/__tests__/github_push_to_main_event.json
+++ b/src/environment/__tests__/github_push_to_main_event.json
@@ -1,0 +1,12 @@
+{
+  "ref": "refs/heads/main",
+  "before": "1111111111111111111111111111111111111111",
+  "after": "0000000000000000000000000000000000000000",
+  "head_commit": {
+    "url": "https://github.com/Codertocat/Hello-World/commit/0000000000000000000000000000000000000000"
+  },
+  "repository": {
+    "html_url": "https://github.com/Codertocat/Hello-World",
+    "default_branch": "main"
+  }
+}

--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -322,13 +322,29 @@ describe('resolveEnvironment', () => {
     assert.equal(result.link, `https://github.com/foo/bar/commit/${afterSha}`);
     assert.notEqual(result.message, undefined);
 
+    // Try with a push to the default branch (e.g. a merge commit landing on main) — no comparison
+    const pushToMainEventContents = fs.readFileSync(
+      path.resolve(__dirname, 'github_push_to_main_event.json'),
+      'utf8',
+    );
+    const pushToMainEventContentsWithChanges = pushToMainEventContents.replaceAll(
+      '0000000000000000000000000000000000000000',
+      afterSha,
+    );
+    const pushToMainEventPath = tmpfs.fullPath('github_push_to_main_event.json');
+    fs.writeFileSync(pushToMainEventPath, pushToMainEventContentsWithChanges);
+    githubEnv.GITHUB_EVENT_PATH = pushToMainEventPath;
+    result = await resolveEnvironment({}, githubEnv);
+    assert.equal(result.afterSha, afterSha);
+    assert.equal(result.beforeSha, afterSha, 'push to default branch should not create a comparison');
+
     // Try with a workflow_dispatch event
     githubEnv.GITHUB_EVENT_PATH = path.resolve(
       __dirname,
       'github_workflow_dispatch.json',
     );
     result = await resolveEnvironment({}, githubEnv);
-    
+
     assert.equal(result.afterSha, afterSha);
     assert.equal(result.beforeSha, afterSha);
     assert.equal(

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -27,7 +27,9 @@ interface GitHubEvent {
   };
   repository?: {
     html_url: string;
+    default_branch?: string;
   };
+  ref?: string;
   before?: string;
   after?: string;
 }
@@ -401,6 +403,15 @@ async function resolveBeforeSha(
 
     if (ghEvent.merge_group) {
       return ghEvent.merge_group.base_sha;
+    }
+
+    // Don't create a comparison for pushes to the default branch (e.g. a merge commit landing on main).
+    if (
+      ghEvent.ref &&
+      ghEvent.repository?.default_branch &&
+      ghEvent.ref === `refs/heads/${ghEvent.repository.default_branch}`
+    ) {
+      return undefined;
     }
 
     return ghEvent.before;


### PR DESCRIPTION
## Summary

- When a merge commit lands on the default branch (e.g. `main`), the GitHub Actions push event has different `before` and `after` SHAs, causing Happo to incorrectly create a comparison instead of just a report
- Fixed by checking if the push event `ref` matches `refs/heads/<default_branch>` — if so, `resolveBeforeSha` returns `undefined`, which causes `beforeSha` to equal `afterSha` and skips comparison creation (same behavior as `workflow_dispatch` events)
- Added a `github_push_to_main_event.json` fixture and a test case to cover this scenario

## Test plan

- [ ] Run `pnpm test environment` — all 14 tests should pass
- [ ] Merge a PR to a repo with Happo configured on GitHub Actions and verify no comparison is created for the main branch build

🤖 Generated with [Claude Code](https://claude.com/claude-code)