### PR TITLE
Guard e2e finalizeHappoReport against same-SHA comparison

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -13,6 +13,7 @@ const config: Config = defineConfig(
   {
     ignores: [
       '**/test-assets/**',
+      '**/__tests__/fixtures/**',
       '.out/**',
       '.happo-out/**',
       'coverage/**',

--- a/src/e2e/__tests__/fixtures/post-snap-request.cjs
+++ b/src/e2e/__tests__/fixtures/post-snap-request.cjs
@@ -1,0 +1,12 @@
+const http = require('http');
+const req = http.request(
+  { port: process.env.HAPPO_E2E_PORT, method: 'POST', path: '/' },
+  function (res) {
+    res.resume();
+    res.on('end', function () {
+      process.exit(0);
+    });
+  },
+);
+req.write('1\n');
+req.end();

--- a/src/e2e/__tests__/wrapper.test.ts
+++ b/src/e2e/__tests__/wrapper.test.ts
@@ -14,12 +14,9 @@ let comparisonEndpointHits: number;
 const happoConfig = () => ({
   apiKey: 'test-key',
   apiSecret: 'test-secret',
-  targets: {} as Record<string, never>,
-  project: undefined,
-  notify: undefined,
+  targets: {},
   endpoint: `http://localhost:${serverPort}`,
   githubApiUrl: 'https://api.github.com',
-  deepCompare: undefined,
   integration: { type: 'playwright' as const },
 });
 

--- a/src/e2e/__tests__/wrapper.test.ts
+++ b/src/e2e/__tests__/wrapper.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import http from 'node:http';
+import path from 'node:path';
 import { after, before, beforeEach, describe, it } from 'node:test';
 
 import runWithWrapper from '../wrapper.ts';
@@ -45,7 +46,9 @@ before(async () => {
       res.setHeader('Content-Type', 'application/json');
 
       if (req.url?.match(/^\/api\/jobs\//)) {
-        res.end(JSON.stringify({ id: 1, url: `http://localhost:${serverPort}/job/1` }));
+        res.end(
+          JSON.stringify({ id: 1, url: `http://localhost:${serverPort}/job/1` }),
+        );
         return;
       }
 
@@ -86,30 +89,42 @@ beforeEach(() => {
   comparisonEndpointHits = 0;
 });
 
-// A node one-liner that POSTs one snap request ID to the e2e server then exits.
+// Script that POSTs one snap request ID to the e2e server then exits.
+// Using a fixture file avoids cmd.exe quoting issues on Windows.
 const childCommand = [
   process.execPath,
-  '-e',
-  `
-    const http = require('http');
-    const req = http.request(
-      { port: process.env.HAPPO_E2E_PORT, method: 'POST', path: '/' },
-      (res) => { res.resume(); res.on('end', () => process.exit(0)); }
-    );
-    req.write('1\\n');
-    req.end();
-  `,
+  path.join(import.meta.dirname, 'fixtures', 'post-snap-request.cjs'),
 ];
 
 describe('runWithWrapper', () => {
-  it('creates a comparison when beforeSha differs from afterSha', { timeout: 5000 }, async () => {
-    await runWithWrapper(childCommand, happoConfig(), baseEnvironment, console, 'happo.config.js');
-    assert.equal(comparisonEndpointHits, 1);
-  });
+  it(
+    'creates a comparison when beforeSha differs from afterSha',
+    { timeout: 5000 },
+    async () => {
+      await runWithWrapper(
+        childCommand,
+        happoConfig(),
+        baseEnvironment,
+        console,
+        'happo.config.js',
+      );
+      assert.equal(comparisonEndpointHits, 1);
+    },
+  );
 
-  it('skips comparison when beforeSha equals afterSha (default branch build)', { timeout: 5000 }, async () => {
-    const environment = { ...baseEnvironment, beforeSha: AFTER_SHA };
-    await runWithWrapper(childCommand, happoConfig(), environment, console, 'happo.config.js');
-    assert.equal(comparisonEndpointHits, 0);
-  });
+  it(
+    'skips comparison when beforeSha equals afterSha (default branch build)',
+    { timeout: 5000 },
+    async () => {
+      const environment = { ...baseEnvironment, beforeSha: AFTER_SHA };
+      await runWithWrapper(
+        childCommand,
+        happoConfig(),
+        environment,
+        console,
+        'happo.config.js',
+      );
+      assert.equal(comparisonEndpointHits, 0);
+    },
+  );
 });

--- a/src/e2e/__tests__/wrapper.test.ts
+++ b/src/e2e/__tests__/wrapper.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert';
+import http from 'node:http';
+import { after, before, beforeEach, describe, it } from 'node:test';
+
+import runWithWrapper from '../wrapper.ts';
+
+const BEFORE_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1';
+const AFTER_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2';
+
+let server: http.Server;
+let serverPort: number;
+let comparisonEndpointHits: number;
+
+const happoConfig = () => ({
+  apiKey: 'test-key',
+  apiSecret: 'test-secret',
+  targets: {} as Record<string, never>,
+  project: undefined,
+  notify: undefined,
+  endpoint: `http://localhost:${serverPort}`,
+  githubApiUrl: 'https://api.github.com',
+  deepCompare: undefined,
+  integration: { type: 'playwright' as const },
+});
+
+const baseEnvironment = {
+  beforeSha: BEFORE_SHA,
+  afterSha: AFTER_SHA,
+  link: undefined,
+  message: undefined,
+  authorEmail: undefined,
+  nonce: undefined,
+  debugMode: false,
+  notify: undefined,
+  fallbackShas: undefined,
+  githubToken: undefined,
+  ci: false,
+  skip: undefined,
+  only: undefined,
+};
+
+before(async () => {
+  await new Promise<void>((resolve) => {
+    server = http.createServer((req, res) => {
+      // Connection: close prevents undici from pooling connections, which
+      // would otherwise keep the event loop alive and hang the test process.
+      res.setHeader('Connection', 'close');
+      res.setHeader('Content-Type', 'application/json');
+
+      if (req.url?.match(/^\/api\/jobs\//)) {
+        res.end(JSON.stringify({ id: 1, url: `http://localhost:${serverPort}/job/1` }));
+        return;
+      }
+
+      if (req.url?.match(/^\/api\/async-reports\//)) {
+        res.end(JSON.stringify({ id: 1 }));
+        return;
+      }
+
+      if (req.url?.match(/^\/api\/reports\/.*\/compare\//)) {
+        comparisonEndpointHits++;
+        res.end(
+          JSON.stringify({
+            id: 1,
+            statusImageUrl: 'http://example.com/status.png',
+            compareUrl: 'http://example.com/compare',
+          }),
+        );
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: 'not found' }));
+    });
+
+    server.listen(0, () => {
+      serverPort = (server.address() as { port: number }).port;
+      resolve();
+    });
+  });
+});
+
+after(() => {
+  server.closeAllConnections();
+  server.close();
+});
+
+beforeEach(() => {
+  comparisonEndpointHits = 0;
+});
+
+// A node one-liner that POSTs one snap request ID to the e2e server then exits.
+const childCommand = [
+  process.execPath,
+  '-e',
+  `
+    const http = require('http');
+    const req = http.request(
+      { port: process.env.HAPPO_E2E_PORT, method: 'POST', path: '/' },
+      (res) => { res.resume(); res.on('end', () => process.exit(0)); }
+    );
+    req.write('1\\n');
+    req.end();
+  `,
+];
+
+describe('runWithWrapper', () => {
+  it('creates a comparison when beforeSha differs from afterSha', { timeout: 5000 }, async () => {
+    await runWithWrapper(childCommand, happoConfig(), baseEnvironment, console, 'happo.config.js');
+    assert.equal(comparisonEndpointHits, 1);
+  });
+
+  it('skips comparison when beforeSha equals afterSha (default branch build)', { timeout: 5000 }, async () => {
+    const environment = { ...baseEnvironment, beforeSha: AFTER_SHA };
+    await runWithWrapper(childCommand, happoConfig(), environment, console, 'happo.config.js');
+    assert.equal(comparisonEndpointHits, 0);
+  });
+});

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -136,7 +136,7 @@ async function finalizeHappoReport(
 
   const { nonce } = environment;
 
-  if (!nonce) {
+  if (!nonce && environment.beforeSha !== environment.afterSha) {
     // If there is a nonce, the comparison will happen when the finalize
     // command is called.
     const compareResult = await createAsyncComparison(


### PR DESCRIPTION
## Summary

Follow-up to #479. After that fix, `beforeSha` equals `afterSha` on default-branch builds, but `finalizeHappoReport` in `src/e2e/wrapper.ts` was calling `createAsyncComparison` without the same guard — causing Cypress and Playwright jobs on main to throw:

```
Cannot create an async comparison between the same SHA (beforeSha=..., afterSha=...)
```

The fix applies the existing `beforeSha !== afterSha` guard (already present in `finalizeAll` and `cli/index.ts`) to the `finalizeHappoReport` path as well.

## Test plan

- [ ] Verify Cypress and Playwright jobs on the main branch no longer throw a same-SHA comparison error

🤖 Generated with [Claude Code](https://claude.com/claude-code)