### PR TITLE
Fix message resolving as null for non-default-branch GitHub Actions builds

### DIFF
--- a/src/environment/__tests__/github_merge_group_event.json
+++ b/src/environment/__tests__/github_merge_group_event.json
@@ -1,7 +1,10 @@
 {
   "merge_group": {
     "head_sha": "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
-    "base_sha": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e"
+    "base_sha": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e",
+    "head_commit": {
+      "message": "Commit from merge group"
+    }
   },
   "repository": {
     "html_url": "https://github.com/Codertocat/Hello-World"

--- a/src/environment/__tests__/github_push_event.json
+++ b/src/environment/__tests__/github_push_event.json
@@ -9,7 +9,7 @@
   "compare": "https://github.com/Codertocat/Hello-World/compare/6113728f27ae...000000000000",
   "commits": [],
   "head_commit": {
-    "__henrics_comment": "For some reason, head_commit is null in the event payload example at https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push . This has never occured in the wild.",
+    "__henrics_comment": "For some reason, head_commit is null in the event payload example at https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push . This has never occurred in the wild.",
     "url": "https://github.com/foo/bar/commit/0000000000000000000000000000000000000000",
     "message": "Commit from push event"
   },

--- a/src/environment/__tests__/github_push_event.json
+++ b/src/environment/__tests__/github_push_event.json
@@ -10,7 +10,8 @@
   "commits": [],
   "head_commit": {
     "__henrics_comment": "For some reason, head_commit is null in the event payload example at https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push . This has never occured in the wild.",
-    "url": "https://github.com/foo/bar/commit/0000000000000000000000000000000000000000"
+    "url": "https://github.com/foo/bar/commit/0000000000000000000000000000000000000000",
+    "message": "Commit from push event"
   },
   "repository": {
     "id": 186853002,

--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -302,6 +302,16 @@ describe('resolveEnvironment', () => {
     assert.equal(result.link, 'https://github.com/Codertocat/Hello-World/pull/2');
     assert.equal(result.message, 'Update the README with new information.');
 
+    // When pull_request.title is null, fall back to git log
+    const prEventWithNullTitle = JSON.parse(prEventContentsWithChanges) as {
+      pull_request: { title: string | null };
+    };
+    prEventWithNullTitle.pull_request.title = null;
+    tmpfs.writeFile('github_pr_null_title_event.json', JSON.stringify(prEventWithNullTitle));
+    githubEnv.GITHUB_EVENT_PATH = tmpfs.fullPath('github_pr_null_title_event.json');
+    result = await resolveEnvironment({}, githubEnv);
+    assert.equal(result.message, 'Add new-branch-file.txt');
+
     // Try with a push event
     // Copy the event file to the temp dir and update the sha to the current sha
     const pushEventContents = fs.readFileSync(
@@ -320,7 +330,7 @@ describe('resolveEnvironment', () => {
     assert.equal(result.afterSha, afterSha);
     assert.equal(result.beforeSha, '6113728f27ae82c7b1a177c8d03f9e96e0adf246');
     assert.equal(result.link, `https://github.com/foo/bar/commit/${afterSha}`);
-    assert.notEqual(result.message, undefined);
+    assert.equal(result.message, 'Commit from push event');
 
     // Try with a push to the default branch (e.g. a merge commit landing on main) — no comparison
     const pushToMainEventContents = fs.readFileSync(

--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -599,6 +599,7 @@ describe('resolveEnvironment', () => {
       result.link,
       'https://github.com/Codertocat/Hello-World/commit/ec26c3e57ca3a959ca5aad62de7213c562f8c821',
     );
+    assert.equal(result.message, 'Commit from merge group');
   });
 
   it('resolves the Travis environment', async () => {

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -27,6 +27,9 @@ interface GitHubEvent {
   merge_group?: {
     head_sha: string;
     base_sha: string;
+    head_commit?: {
+      message?: string;
+    };
   };
   repository?: {
     html_url: string;
@@ -240,6 +243,9 @@ async function resolveMessage(
     }
     if (ghEvent.head_commit?.message) {
       return ghEvent.head_commit.message;
+    }
+    if (ghEvent.merge_group?.head_commit?.message) {
+      return ghEvent.merge_group.head_commit.message;
     }
   }
 

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -20,16 +20,20 @@ interface GitHubEvent {
       sha: string;
     };
   };
-  head_commit?: {
-    url: string;
-    message?: string;
-  };
+  head_commit?:
+    | {
+        url: string;
+        message?: string;
+      }
+    | null;
   merge_group?: {
     head_sha: string;
     base_sha: string;
-    head_commit?: {
-      message?: string;
-    };
+    head_commit?:
+      | {
+          message?: string;
+        }
+      | null;
   };
   repository?: {
     html_url: string;

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -7,10 +7,12 @@ import type { ParsedCLIArgs } from '../cli/parseOptions.ts';
 const NUMBER_OF_COMMITS_TO_FETCH = 50;
 const FULL_SHA_REGEX = /^[a-f0-9]{40}$/i;
 
+// Subset of the GitHub webhook event payload shapes written to GITHUB_EVENT_PATH.
+// See https://docs.github.com/en/webhooks/webhook-events-and-payloads for full schemas.
 interface GitHubEvent {
   pull_request?: {
     html_url: string;
-    title: string;
+    title: string | null;
     base: {
       sha: string;
     };
@@ -20,6 +22,7 @@ interface GitHubEvent {
   };
   head_commit?: {
     url: string;
+    message?: string;
   };
   merge_group?: {
     head_sha: string;
@@ -231,8 +234,11 @@ async function resolveMessage(
 
   if (GITHUB_EVENT_PATH) {
     const ghEvent = await resolveGithubEvent(GITHUB_EVENT_PATH);
-    if (ghEvent.pull_request) {
+    if (ghEvent.pull_request?.title !== null && ghEvent.pull_request?.title !== undefined) {
       return ghEvent.pull_request.title;
+    }
+    if (ghEvent.head_commit?.message) {
+      return ghEvent.head_commit.message;
     }
   }
 

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -234,8 +234,9 @@ async function resolveMessage(
 
   if (GITHUB_EVENT_PATH) {
     const ghEvent = await resolveGithubEvent(GITHUB_EVENT_PATH);
-    if (ghEvent.pull_request?.title !== null && ghEvent.pull_request?.title !== undefined) {
-      return ghEvent.pull_request.title;
+    const title = ghEvent.pull_request?.title;
+    if (typeof title === 'string') {
+      return title;
     }
     if (ghEvent.head_commit?.message) {
       return ghEvent.head_commit.message;


### PR DESCRIPTION
## Summary

- Fixes `pull_request.title` being `null` at runtime (despite the TypeScript type saying `string`) causing the message to be sent as JSON `null` to the API. When the title is null, we now fall through to `git log` instead of returning early.
- Adds `head_commit.message` as a message source for push events on GitHub Actions, before falling back to `git log`. This is more reliable in shallow-clone environments.
- Adds `merge_group.head_commit.message` as a message source for merge queue builds on GitHub Actions.
- Updates the `GitHubEvent` interface to accurately reflect that `title` can be `null` per the GitHub API, and adds a link to the [GitHub webhook event payload docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads).

## Test plan

- [x] New test: `pull_request.title = null` falls back to `git log` commit message
- [x] Updated test: push event uses `head_commit.message` directly (previously just asserted `!== undefined`)
- [x] Updated test: merge group event uses `merge_group.head_commit.message`
- [x] All existing environment tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)