### PR TITLE
Fix --skip for custom builds that replace the document on render

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,14 @@ jobs:
       - uses: ./.github/actions/setup-env
       - run: pnpm test:custom
 
+  custom-skipped:
+    runs-on: ubuntu-latest
+    name: Happo Custom (skipped examples)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-env
+      - run: pnpm test:custom:skipped
+
   pages:
     runs-on: ubuntu-latest
     name: Happo Pages

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           happo-api-key: ${{ secrets.HAPPO_API_KEY }}
           happo-api-secret: ${{ secrets.HAPPO_API_SECRET }}
-          projects: 'cypress,storybook-v9,storybook-v10,storybook-skipped,storybook-only,playwright,playwright-nonce,custom,pages'
+          projects: 'cypress,storybook-v9,storybook-v10,storybook-skipped,storybook-only,playwright,playwright-nonce,custom,custom-skipped,pages'
 
   cypress:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "storybook:dev": "storybook dev --config-dir src/storybook/__tests__/storybook-app -p ${PORT:-6007}",
     "test": "node --env-file-if-exists=.env.local ./scripts/test.ts",
     "test:custom": "pnpm build:dist && pnpm build:custom && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.custom.config.ts",
+    "test:custom:skipped": "pnpm build:dist && pnpm build:custom && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.custom.config.ts --project custom-skipped --skip \"$(node ./scripts/getCustomSkip.ts)\"",
     "test:cypress": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.cypress.config.ts e2e -- cypress run -C src/cypress/__cypress__/cypress.config.ts",
     "test:cypress:open": "cypress open -C src/cypress/__cypress__/cypress.config.ts",
     "test:playwright": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright.config.ts e2e -- playwright test",

--- a/scripts/getCustomSkip.ts
+++ b/scripts/getCustomSkip.ts
@@ -1,0 +1,23 @@
+/**
+ * Outputs a --skip JSON argument for the happo.custom.config.ts test run.
+ *
+ * Skips two of the four "Page" examples registered in
+ * `src/custom/__happo__/index.ts`. The skipped variants come *after* an
+ * unskipped "Page" example whose render function replaces the entire
+ * document via `document.open()` / `document.write()`. That destroys the
+ * `<script id="happo-skipped">` tag injected into iframe.html, which is
+ * how `--skip` is currently delivered to the browser. If `--skip` is
+ * working correctly, the Page "two" and "four" snapshots should be
+ * borrowed from the baseline via the extends-report snap-request and not
+ * re-rendered by the workers.
+ *
+ * Usage:
+ *   node scripts/getCustomSkip.ts
+ */
+
+process.stdout.write(
+  JSON.stringify([
+    { component: 'Page', variant: 'two' },
+    { component: 'Page', variant: 'four' },
+  ]),
+);

--- a/src/custom/__happo__/index.ts
+++ b/src/custom/__happo__/index.ts
@@ -17,3 +17,24 @@ happoStatic.registerExample({
     document.body.innerHTML = '<div style="background-color:blue">Hello</div>';
   },
 });
+
+// The "Page" examples below render by replacing the entire document via
+// `document.open()` / `document.write()` / `document.close()`. This is how
+// the happo.io docs site (and other custom integrations that snapshot full
+// HTML pages) render their examples. Each `document.write` wipes out the
+// `<script id="happo-skipped">` tag injected into iframe.html by `--skip`,
+// so these examples exercise the code path that has to read the skip set
+// before any rendering happens.
+for (const variant of ['one', 'two', 'three', 'four']) {
+  happoStatic.registerExample({
+    component: 'Page',
+    variant,
+    render: () => {
+      document.open();
+      document.write(
+        `<!DOCTYPE html><html><body><h1 style="font-family:sans-serif">Page ${variant}</h1></body></html>`,
+      );
+      document.close();
+    },
+  });
+}

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -23,6 +23,23 @@ const happoStatic = {
       init: ({ targetName, chunk, only }) => {
         currentIndex = 0;
 
+        // Read the skip set from the DOM and filter `examples` once, here
+        // at init time. An example's `render` may replace the entire
+        // document (e.g. `document.open()`/`write()`/`close()`), which
+        // would destroy the `<script id="happo-skipped">` tag injected
+        // into iframe.html. Filtering up front means the skip list is
+        // robust against any DOM mutation an example might perform.
+        const happoSkippedEl =
+          typeof document === 'undefined'
+            ? null
+            : document.getElementById('happo-skipped');
+        const skipSet = toSkipSet(
+          parseSkip(happoSkippedEl?.textContent ?? undefined),
+        );
+        examples = examples.filter(
+          (e) => !isInSkipSet(skipSet, e.component, e.variant),
+        );
+
         if (only) {
           examples = examples.filter(
             (e) => e.component === only.component && e.variant === only.variant,
@@ -47,41 +64,24 @@ const happoStatic = {
       },
 
       nextExample: async () => {
-        const happoSkippedEl =
-          typeof document === 'undefined'
-            ? null
-            : document.getElementById('happo-skipped');
-        const skipSet = toSkipSet(
-          parseSkip(happoSkippedEl?.textContent ?? undefined),
-        );
+        const example = examples[currentIndex];
 
-        while (true) {
-          const example = examples[currentIndex];
-
-          if (!example) {
-            // we're done
-            return;
-          }
-
-          if (isInSkipSet(skipSet, example.component, example.variant)) {
-            currentIndex++;
-            continue;
-          }
-
-          if (example.render) {
-            await example.render();
-          }
-          currentIndex++;
-
-          const clone = {
-            component: example.component,
-            variant: example.variant,
-            targets: example.targets,
-            waitForContent: example.waitForContent,
-          };
-
-          return clone;
+        if (!example) {
+          // we're done
+          return;
         }
+
+        if (example.render) {
+          await example.render();
+        }
+        currentIndex++;
+
+        return {
+          component: example.component,
+          variant: example.variant,
+          targets: example.targets,
+          waitForContent: example.waitForContent,
+        };
       },
     };
   },


### PR DESCRIPTION
## Summary

- Move skip filtering from `nextExample` into `init` in the custom integration so the skip list is read from the DOM once, before any example's `render` runs.
- Custom integrations whose render functions call `document.open()` / `document.write()` / `document.close()` (e.g. the happo.io docs site) were wiping out the `<script id="happo-skipped">` tag injected into iframe.html, so subsequent `nextExample` calls saw an empty skip set and rendered everything. The extends-report snap-request was correct, but the individual snap-requests still rendered the skipped examples — wasted work on the workers.
- Add a custom reproducer: `Page` examples in `src/custom/__happo__/index.ts` that use `document.write`, a `scripts/getCustomSkip.ts` helper, and a `test:custom:skipped` npm script.

## Test plan

- [x] `pnpm test custom` — existing unit tests still pass
- [x] `pnpm lint`
- [x] `pnpm build:custom`
- [ ] Seed a `custom-skipped` baseline (run the equivalent of `test:custom` with `--project custom-skipped` once), then run `pnpm test:custom:skipped` and confirm the individual snap-requests no longer include `Page two` / `Page four` — they should come from the extends-report instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)