### PR TITLE
Fix report message including full commit body for push/merge-group events

### DIFF
--- a/src/environment/__tests__/github_merge_group_event.json
+++ b/src/environment/__tests__/github_merge_group_event.json
@@ -3,7 +3,7 @@
     "head_sha": "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
     "base_sha": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e",
     "head_commit": {
-      "message": "Commit from merge group"
+      "message": "Commit from merge group\n\nThis is the body of the commit message.\nIt can span multiple lines."
     }
   },
   "repository": {

--- a/src/environment/__tests__/github_push_event.json
+++ b/src/environment/__tests__/github_push_event.json
@@ -11,7 +11,7 @@
   "head_commit": {
     "__henrics_comment": "For some reason, head_commit is null in the event payload example at https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push . This has never occurred in the wild.",
     "url": "https://github.com/foo/bar/commit/0000000000000000000000000000000000000000",
-    "message": "Commit from push event"
+    "message": "Commit from push event\n\nThis is the body of the commit message.\nIt can span multiple lines."
   },
   "repository": {
     "id": 186853002,

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -228,6 +228,11 @@ async function resolveAuthorEmail(
   return res.stdout.trim();
 }
 
+function firstLine(message: string): string {
+  const newlineIndex = message.indexOf('\n');
+  return newlineIndex === -1 ? message : message.slice(0, newlineIndex);
+}
+
 async function resolveMessage(
   cliArgs: ParsedCLIArgs,
   env: Record<string, string | undefined>,
@@ -246,10 +251,10 @@ async function resolveMessage(
       return title;
     }
     if (ghEvent.head_commit?.message) {
-      return ghEvent.head_commit.message.split('\n')[0];
+      return firstLine(ghEvent.head_commit.message);
     }
     if (ghEvent.merge_group?.head_commit?.message) {
-      return ghEvent.merge_group.head_commit.message.split('\n')[0];
+      return firstLine(ghEvent.merge_group.head_commit.message);
     }
   }
 

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -246,10 +246,10 @@ async function resolveMessage(
       return title;
     }
     if (ghEvent.head_commit?.message) {
-      return ghEvent.head_commit.message;
+      return ghEvent.head_commit.message.split('\n')[0];
     }
     if (ghEvent.merge_group?.head_commit?.message) {
-      return ghEvent.merge_group.head_commit.message;
+      return ghEvent.merge_group.head_commit.message.split('\n')[0];
     }
   }
 


### PR DESCRIPTION
## Summary

- `head_commit.message` from GitHub's push and merge-group events contains the full commit message (subject + blank line + body). For PR merge commits this meant the entire PR description was used as the report title.
- Fix: take only the first line (`.split('\n')[0]`), matching the existing git-log fallback that already uses `--pretty=%s`.
- Updated the push and merge-group event fixtures to use multi-line messages so the tests actually exercise the fix.

## Test plan

- [x] Existing assertions (`'Commit from push event'` and `'Commit from merge group'`) now act as regression tests — they pass only if the body is stripped
- [x] All 377 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)