### PR TITLE
Skip rendering for empty --only and extend full report from baseline

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -430,7 +430,15 @@ async function handleDefaultCommand(
           await import('../network/findBaselineReport.ts')
         ).default;
         baselineSha = await findBaselineReport(environment, config, logger);
-        if (!baselineSha) {
+      }
+
+      if (!baselineSha) {
+        if (only.length === 0) {
+          logger.log(
+            '[HAPPO] No baseline report found for empty --only run. Generating a full report instead.',
+          );
+          only = undefined;
+        } else {
           logger.log(
             '[HAPPO] No baseline report found for --only run. Excluded stories will not be borrowed from a baseline.',
           );

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -175,11 +175,15 @@ export default async function prepareSnapRequests(
       throw new Error('--only is not supported for the pages integration');
     }
     const { resolvedSkip } = await buildPackage(config, logger, skip, only);
-    const result: PrepareSnapRequestsResult = { snapRequestIds: [] };
-    if (resolvedSkip !== undefined) {
-      result.resolvedSkip = resolvedSkip;
+    if (!resolvedSkip || resolvedSkip.length === 0) {
+      // Without a component list we can't construct a meaningful
+      // extends-report, and the alternative would be an async report with
+      // zero snap requests. Surface the failure instead.
+      throw new Error(
+        'Empty --only run could not enumerate any components from the build. An empty --only run requires a readable Storybook index.json (or equivalent) to know which components to borrow from the baseline.',
+      );
     }
-    return result;
+    return { snapRequestIds: [], resolvedSkip };
   }
 
   const prepareResult =

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -165,6 +165,23 @@ export default async function prepareSnapRequests(
   only?: Array<OnlyItem>,
 ): Promise<PrepareSnapRequestsResult> {
   const logger = new Logger();
+
+  // An empty --only array means: render nothing locally and borrow the entire
+  // report from the baseline via an extends-report. Build the package only to
+  // enumerate components for the extends-report; skip upload and target
+  // execution.
+  if (only !== undefined && only.length === 0) {
+    if (config.integration.type === 'pages') {
+      throw new Error('--only is not supported for the pages integration');
+    }
+    const { resolvedSkip } = await buildPackage(config, logger, skip, only);
+    const result: PrepareSnapRequestsResult = { snapRequestIds: [] };
+    if (resolvedSkip !== undefined) {
+      result.resolvedSkip = resolvedSkip;
+    }
+    return result;
+  }
+
   const prepareResult =
     config.integration.type === 'pages'
       ? null

--- a/src/storybook/__tests__/index.test.ts
+++ b/src/storybook/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { before, describe, it } from 'node:test';
 
@@ -81,6 +82,51 @@ describe('happoStorybookPlugin', () => {
       assert.ok(result.resolvedSkip);
       const components = new Set(result.resolvedSkip.map((s) => s.component));
       assert.deepStrictEqual(components, new Set(['Stories', 'Interactive']));
+    });
+
+    it('with empty --only, components no longer present locally are not borrowed', async () => {
+      // Simulate "Interactive" being deleted from the local Storybook by
+      // pointing the plugin at a temp copy of the prebuilt package whose
+      // index.json has had the Interactive entries removed. The extends-report
+      // should only borrow components that still exist locally, so deleted
+      // stories stay deleted.
+      const tempDir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'happo-only-empty-deleted-'),
+      );
+      try {
+        await fs.promises.copyFile(
+          path.join(packageDir, 'iframe.html'),
+          path.join(tempDir, 'iframe.html'),
+        );
+        const indexContent = await fs.promises.readFile(
+          path.join(packageDir, 'index.json'),
+          'utf8',
+        );
+        const indexData = JSON.parse(indexContent) as {
+          entries?: Record<string, { title?: string }>;
+        };
+        const filteredEntries: Record<string, unknown> = {};
+        for (const [id, entry] of Object.entries(indexData.entries ?? {})) {
+          if (entry.title !== 'Interactive') {
+            filteredEntries[id] = entry;
+          }
+        }
+        await fs.promises.writeFile(
+          path.join(tempDir, 'index.json'),
+          JSON.stringify({ ...indexData, entries: filteredEntries }),
+        );
+
+        const result = await happoStorybookPlugin({
+          usePrebuiltPackage: true,
+          outputDir: tempDir,
+          only: [],
+        });
+        assert.ok(result.resolvedSkip);
+        const components = new Set(result.resolvedSkip.map((s) => s.component));
+        assert.deepStrictEqual(components, new Set(['Stories']));
+      } finally {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/storybook/__tests__/index.test.ts
+++ b/src/storybook/__tests__/index.test.ts
@@ -69,5 +69,18 @@ describe('happoStorybookPlugin', () => {
       });
       assert.strictEqual(result.estimatedSnapsCount, 20);
     });
+
+    it('treats an empty --only array as "borrow everything from baseline"', async () => {
+      const result = await happoStorybookPlugin({
+        usePrebuiltPackage: true,
+        only: [],
+      });
+      assert.strictEqual(result.estimatedSnapsCount, 0);
+      // resolvedSkip should contain every component in the storybook so the
+      // extends-report can borrow them all from the baseline.
+      assert.ok(result.resolvedSkip);
+      const components = new Set(result.resolvedSkip.map((s) => s.component));
+      assert.deepStrictEqual(components, new Set(['Stories', 'Interactive']));
+    });
   });
 });

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -145,31 +145,42 @@ export default async function buildStorybookPackage({
       }
 
       if (only !== undefined) {
-        resolvedOnly = resolveStoryFileItems(only as Array<SkipItem>, entries).map(
-          ({ component }) => ({ component }),
-        );
-        if (resolvedOnly.length === 0) {
-          console.warn(
-            '[HAPPO] --only: no matching stories found in Storybook index. Generating a full report instead.',
-          );
-          resolvedOnly = undefined;
-        } else {
-          // Adjust the count so auto-chunking reflects only the stories that
-          // will actually be rendered (only matching examples need a chunk slot).
-          const onlyComponents = new Set(resolvedOnly.map((item) => item.component));
-          estimatedSnapsCount = storyEntries.filter((e) =>
-            onlyComponents.has(e.title ?? ''),
-          ).length;
-
-          // Compute the complement: all components NOT in the only list.
-          // These will be borrowed from the baseline via an extends-report.
+        if (only.length === 0) {
+          // Empty --only: nothing is rendered locally; every component is
+          // borrowed from the baseline via an extends-report.
           const allComponents = new Set<string>();
           for (const e of storyEntries) {
             if (e.title) allComponents.add(e.title);
           }
-          resolvedSkip = [...allComponents]
-            .filter((c) => !onlyComponents.has(c))
-            .map((component) => ({ component }));
+          resolvedSkip = [...allComponents].map((component) => ({ component }));
+          estimatedSnapsCount = 0;
+        } else {
+          resolvedOnly = resolveStoryFileItems(only as Array<SkipItem>, entries).map(
+            ({ component }) => ({ component }),
+          );
+          if (resolvedOnly.length === 0) {
+            console.warn(
+              '[HAPPO] --only: no matching stories found in Storybook index. Generating a full report instead.',
+            );
+            resolvedOnly = undefined;
+          } else {
+            // Adjust the count so auto-chunking reflects only the stories that
+            // will actually be rendered (only matching examples need a chunk slot).
+            const onlyComponents = new Set(resolvedOnly.map((item) => item.component));
+            estimatedSnapsCount = storyEntries.filter((e) =>
+              onlyComponents.has(e.title ?? ''),
+            ).length;
+
+            // Compute the complement: all components NOT in the only list.
+            // These will be borrowed from the baseline via an extends-report.
+            const allComponents = new Set<string>();
+            for (const e of storyEntries) {
+              if (e.title) allComponents.add(e.title);
+            }
+            resolvedSkip = [...allComponents]
+              .filter((c) => !onlyComponents.has(c))
+              .map((component) => ({ component }));
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- When `--only` is given an empty JSON array (`'[]'`), skip the upload and render pipeline entirely and produce a report whose snaps are all borrowed from the baseline via an extends-report snap request.
- For Storybook, the build still runs so we can enumerate every component and pass the full list as `extendedSnaps`.
- When no baseline can be found, fall back to a normal full run with a clear log message (parallels the existing `--skip` fallback).

## Test plan
- [x] `pnpm test` (379 tests pass; new test added in `src/storybook/__tests__/index.test.ts` for the empty-`--only` case)
- [x] `pnpm build:types`
- [x] `pnpm lint`
- [ ] Manual: run `happo --only '[]'` against a project with a baseline and verify the resulting report extends the baseline with no fresh renders
- [ ] Manual: run `happo --only '[]'` against a project with no baseline and confirm the full-run fallback message and behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)