### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-cypress/action.yaml
+++ b/.github/actions/setup-cypress/action.yaml
@@ -12,7 +12,7 @@ runs:
         echo "CYPRESS_VERSION=$CYPRESS_VERSION" >> $GITHUB_ENV
 
     - name: Cache Cypress binary
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: cypress-cache
       with:
         path: |

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -10,13 +10,13 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       with:
         version: 11
         run_install: false
 
     - name: Setup Node
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'

--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -12,7 +12,7 @@ runs:
         echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
 
     - name: Cache playwright binaries
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: playwright-cache
       with:
         path: |

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3
+      - uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 # v3.12.0
         with:
           merge-method: 'merge'
           target: 'minor'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Test (Node ${{ matrix.node-version }} on ${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node-version }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Orchestrate Happo Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/orchestrate-happo
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Cypress
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - uses: ./.github/actions/setup-cypress
       - run: pnpm test:cypress
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Happo Custom
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - run: pnpm test:custom
 
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Happo Custom (skipped examples)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - run: pnpm test:custom:skipped
 
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Happo Pages
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - run: pnpm test:pages
 
@@ -87,7 +87,7 @@ jobs:
 
     name: Storybook v${{ matrix.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - if: matrix.dependencies != ''
         run: pnpm add -D ${{ matrix.dependencies }}
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Storybook (skipped examples)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - run: pnpm test:storybook:skipped
 
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Storybook (only examples)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - run: pnpm test:storybook:only
 
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Playwright
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-env
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Playwright (nonce)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-env
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     name: TypeScript
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - run: pnpm tsc
 
@@ -147,6 +147,6 @@ jobs:
     runs-on: ubuntu-latest
     name: ESLint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-env
       - run: pnpm lint


### PR DESCRIPTION
## Summary

- Replace floating tag refs (`@v4`, `@v5`, etc.) for third-party actions under `.github/` with full 40-char commit SHAs plus a `# vX.Y.Z` comment.
- Protects against upstream tag mutation: a tag we trust today can be force-pushed tomorrow, and floating refs would silently pick up the malicious code.
- Dependabot recognizes the `<sha> # <tag>` format and will keep both in sync on future updates.
- In-repo composite actions (`uses: ./...`) are intentionally left alone — they aren't a supply-chain concern.

## Pins

| Action | SHA | Tag |
| --- | --- | --- |
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4.3.0 |
| `actions/setup-node` | `a0853c24544627f65ddf259abe73b1d18a591444` | v5.0.0 |
| `pnpm/action-setup` | `b906affcce14559ad1aafd4ab0e942779e9f58b1` | v4.3.0 |
| `fastify/github-action-merge-dependabot` | `30c3f8f14a4f7b315ba38dbc1b793d27128fef82` | v3.12.0 |

## Test plan

- [ ] CI passes on this branch (all jobs resolve the pinned SHAs successfully).
- [ ] `grep -r "uses:" .github/ | grep -v "@[a-f0-9]\{40\}" | grep -v "uses: \./"` returns no third-party refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)