### PR TITLE
ci: add Dependabot cooldown windows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    cooldown:
+      default-days: 2
     groups:
       patches-and-minors:
         update-types:
@@ -17,3 +19,16 @@ updates:
           - 'eslint'
           - 'eslint-*'
           - '@eslint/*'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        update-types:
+          - 'patch'
+          - 'minor'
+          - 'major'


### PR DESCRIPTION
## Summary

- Add `cooldown` blocks to Dependabot so newly-published versions sit before we bump them. Gives malicious releases time to be yanked or flagged before they land in our tree.
- Add a `github-actions` ecosystem so Dependabot can keep the SHA pins from #495 in sync with their tags going forward.

## Cooldown rationale

- **npm: 2 days.** npm's 72h unpublish window means most malicious releases get pulled before a 2d cooldown expires. pnpm's `minimumReleaseAge` defaults to 24h, so 2d adds a small extra buffer on top.
- **github-actions: 7 days.** Releases are rare and the blast radius is large (an action runs with our repo secrets). We can afford to wait.
- **Docker:** not used in this repo, so no entry.

These numbers are opinions, not gospel — happy to dial them up/down based on risk tolerance.

## Test plan

- [ ] Dependabot picks up the new config on the next scheduled run (visible in repo Insights → Dependency graph → Dependabot).
- [ ] Next Dependabot PR for an npm package is gated by the 2-day cooldown.
- [ ] Next Dependabot PR for a GitHub Action is gated by the 7-day cooldown and rewrites the pinned SHA + comment together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)