### PR TITLE
Add failOnWaitForTimeout config option (default: true)

### DIFF
--- a/src/config/RemoteBrowserTarget.ts
+++ b/src/config/RemoteBrowserTarget.ts
@@ -76,6 +76,12 @@ export interface ExecuteParams {
    * optimal number of parallel chunks.
    */
   estimatedSnapsCount?: number;
+
+  /**
+   * When true, the worker fails the snap if `waitForContent` or
+   * `waitForSelector` times out instead of silently warning.
+   */
+  failOnWaitForTimeout?: boolean;
 }
 
 function getPageSlices(pages: Array<Page>, chunks: number): Array<PageSlice> {
@@ -108,6 +114,7 @@ function buildChunkItem({
   staticPackage,
   assetsPackage,
   targetName,
+  failOnWaitForTimeout,
 }: {
   slice?: Array<unknown> | undefined;
   chunk?: Chunk | undefined;
@@ -120,6 +127,7 @@ function buildChunkItem({
   staticPackage: string | undefined;
   assetsPackage: string | undefined;
   targetName: string | undefined;
+  failOnWaitForTimeout: boolean | undefined;
 }): ChunkItem {
   const payloadString = JSON.stringify({
     viewport,
@@ -132,6 +140,7 @@ function buildChunkItem({
     assetsPackage,
     pages: pageSlice,
     extendsSha: pageSlice ? pageSlice.extendsSha : undefined,
+    failOnWaitForTimeout,
   });
 
   const payloadHash = createHash(payloadString + (pageSlice ? Math.random() : ''));
@@ -235,6 +244,7 @@ export default class RemoteBrowserTarget {
       pages,
       targetName,
       estimatedSnapsCount,
+      failOnWaitForTimeout,
     }: ExecuteParams,
     config: ConfigWithDefaults,
   ): Promise<Array<number>> {
@@ -247,6 +257,7 @@ export default class RemoteBrowserTarget {
       staticPackage,
       assetsPackage,
       targetName,
+      failOnWaitForTimeout,
     };
 
     // Build all chunk items up front

--- a/src/config/__tests__/RemoteBrowserTarget.test.ts
+++ b/src/config/__tests__/RemoteBrowserTarget.test.ts
@@ -164,6 +164,7 @@ describe('RemoteBrowserTarget', () => {
         endpoint: `http://localhost:${address.port}`,
         apiKey: 'test-key',
         apiSecret: 'test-secret',
+        failOnWaitForTimeout: true,
       };
     });
 
@@ -438,6 +439,7 @@ describe('RemoteBrowserTarget', () => {
           },
           config,
         );
+        assert.strictEqual(bulkCalls.length, 1);
         const items = bulkCalls[0]?.items ?? [];
         assert.strictEqual(items.length, 2);
         for (const item of items) {
@@ -458,6 +460,8 @@ describe('RemoteBrowserTarget', () => {
           },
           config,
         );
+        assert.strictEqual(bulkCalls.length, 1);
+        assert.strictEqual(bulkCalls[0]?.items.length, 1);
         const payload = JSON.parse(
           bulkCalls[0]?.items[0]?.payloadString as string,
         ) as { failOnWaitForTimeout?: unknown };
@@ -470,6 +474,8 @@ describe('RemoteBrowserTarget', () => {
           { staticPackage: 'https://example.com/pkg.zip', targetName: 'chrome' },
           config,
         );
+        assert.strictEqual(bulkCalls.length, 1);
+        assert.strictEqual(bulkCalls[0]?.items.length, 1);
         const payload = JSON.parse(
           bulkCalls[0]?.items[0]?.payloadString as string,
         ) as Record<string, unknown>;

--- a/src/config/__tests__/RemoteBrowserTarget.test.ts
+++ b/src/config/__tests__/RemoteBrowserTarget.test.ts
@@ -426,6 +426,57 @@ describe('RemoteBrowserTarget', () => {
       });
     });
 
+    describe('with failOnWaitForTimeout', () => {
+      it('flows failOnWaitForTimeout: true into each item payload (bulk path)', async () => {
+        const target = new RemoteBrowserTarget('chrome', baseTarget);
+        await target.execute(
+          {
+            staticPackage: 'https://example.com/pkg.zip',
+            estimatedSnapsCount: 200,
+            targetName: 'chrome',
+            failOnWaitForTimeout: true,
+          },
+          config,
+        );
+        const items = bulkCalls[0]?.items ?? [];
+        assert.strictEqual(items.length, 2);
+        for (const item of items) {
+          const payload = JSON.parse(item.payloadString as string) as {
+            failOnWaitForTimeout?: unknown;
+          };
+          assert.strictEqual(payload.failOnWaitForTimeout, true);
+        }
+      });
+
+      it('flows failOnWaitForTimeout: false into the item payload', async () => {
+        const target = new RemoteBrowserTarget('chrome', baseTarget);
+        await target.execute(
+          {
+            staticPackage: 'https://example.com/pkg.zip',
+            targetName: 'chrome',
+            failOnWaitForTimeout: false,
+          },
+          config,
+        );
+        const payload = JSON.parse(
+          bulkCalls[0]?.items[0]?.payloadString as string,
+        ) as { failOnWaitForTimeout?: unknown };
+        assert.strictEqual(payload.failOnWaitForTimeout, false);
+      });
+
+      it('omits failOnWaitForTimeout from the payload when not provided', async () => {
+        const target = new RemoteBrowserTarget('chrome', baseTarget);
+        await target.execute(
+          { staticPackage: 'https://example.com/pkg.zip', targetName: 'chrome' },
+          config,
+        );
+        const payload = JSON.parse(
+          bulkCalls[0]?.items[0]?.payloadString as string,
+        ) as Record<string, unknown>;
+        assert.strictEqual('failOnWaitForTimeout' in payload, false);
+      });
+    });
+
     describe('when bulk endpoint responds with invalid shape', () => {
       beforeEach(() => {
         simulateBulkInvalidShape = true;

--- a/src/config/__tests__/loadConfig.test.ts
+++ b/src/config/__tests__/loadConfig.test.ts
@@ -1058,4 +1058,67 @@ describe('loadConfigFile', () => {
       );
     });
   });
+
+  describe('failOnWaitForTimeout validation', () => {
+    it('throws an error if failOnWaitForTimeout is not a boolean', async () => {
+      tmpfs.mock({
+        'happo.config.js': `
+          export default {
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+            targets: {
+              chrome: { type: 'chrome', viewport: '1024x768' },
+            },
+            failOnWaitForTimeout: 'yes',
+          };
+        `,
+      });
+
+      await assert.rejects(
+        loadConfigFile(findConfigFile(), { link: undefined, ci: false }),
+        /Invalid `failOnWaitForTimeout` in config file \S+: must be a boolean, got: "yes"/,
+      );
+    });
+
+    it('accepts failOnWaitForTimeout: false', async () => {
+      tmpfs.mock({
+        'happo.config.js': `
+          export default {
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+            targets: {
+              chrome: { type: 'chrome', viewport: '1024x768' },
+            },
+            failOnWaitForTimeout: false,
+          };
+        `,
+      });
+
+      const config = await loadConfigFile(findConfigFile(), {
+        link: undefined,
+        ci: false,
+      });
+      assert.strictEqual(config.failOnWaitForTimeout, false);
+    });
+
+    it('defaults failOnWaitForTimeout to true when not provided', async () => {
+      tmpfs.mock({
+        'happo.config.js': `
+          export default {
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+            targets: {
+              chrome: { type: 'chrome', viewport: '1024x768' },
+            },
+          };
+        `,
+      });
+
+      const config = await loadConfigFile(findConfigFile(), {
+        link: undefined,
+        ci: false,
+      });
+      assert.strictEqual(config.failOnWaitForTimeout, true);
+    });
+  });
 });

--- a/src/config/__tests__/loadConfig.test.ts
+++ b/src/config/__tests__/loadConfig.test.ts
@@ -1076,7 +1076,7 @@ describe('loadConfigFile', () => {
 
       await assert.rejects(
         loadConfigFile(findConfigFile(), { link: undefined, ci: false }),
-        /Invalid `failOnWaitForTimeout` in config file \S+: must be a boolean, got: "yes"/,
+        /Invalid `failOnWaitForTimeout` in config file \S+: must be a boolean, got: 'yes'/,
       );
     });
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -430,6 +430,7 @@ export interface ConfigWithDefaults extends Config {
   endpoint: NonNullable<Config['endpoint']>;
   githubApiUrl: NonNullable<Config['githubApiUrl']>;
   targets: Record<string, TargetWithDefaults>;
+  failOnWaitForTimeout: NonNullable<Config['failOnWaitForTimeout']>;
 }
 
 export function defineConfig(config: Config): Config {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -105,12 +105,26 @@ export interface Page {
   title: string;
 
   /**
-   * Wait for the content to appear on the page before taking the screenshot.
+   * Wait for the given text content to appear on the page before taking the
+   * screenshot.
+   *
+   * If the content does not appear within the worker's timeout, the snap
+   * fails with a clear error so that stale content strings are surfaced
+   * immediately. Set the top-level `failOnWaitForTimeout: false` option in
+   * your Happo config to restore the legacy behavior of warning and
+   * screenshotting whatever is on the page anyway.
    */
   waitForContent?: string;
 
   /**
-   * Wait for a condition to be true before taking the screenshot.
+   * Wait for an element matching the given selector to appear in the DOM
+   * before taking the screenshot.
+   *
+   * If the selector is not found within the worker's timeout, the snap
+   * fails with a clear error so that stale selectors are surfaced
+   * immediately. Set the top-level `failOnWaitForTimeout: false` option in
+   * your Happo config to restore the legacy behavior of warning and
+   * screenshotting whatever is on the page anyway.
    */
   waitForSelector?: string;
 }
@@ -228,6 +242,27 @@ export interface Config {
    * An object with settings for deep compare.
    */
   deepCompare?: DeepCompareSettings;
+
+  /**
+   * Controls how a Happo worker handles a per-example or per-page
+   * `waitForContent` or `waitForSelector` that times out.
+   *
+   * When `true` (the default), the worker fails the snap with a clear error
+   * so that stale selectors and content strings (e.g. text that no longer
+   * renders after a copy change) are surfaced immediately instead of
+   * producing silent multi-second waits on every run.
+   *
+   * Set to `false` to restore the legacy behavior, where a timeout only
+   * emits a warning in the worker logs and the screenshot is taken anyway.
+   *
+   * It is recommended to always leave this set to `true`. If you encounter
+   * a failure, the preferred fix is to update the offending `waitForContent`
+   * or `waitForSelector` value so that it matches the rendered output.
+   * Setting this option to `false` should be a last resort.
+   *
+   * @default true
+   */
+  failOnWaitForTimeout?: boolean;
 }
 
 type MobileSafariBrowserType = 'ios-safari' | 'ipad-safari';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -108,11 +108,12 @@ export interface Page {
    * Wait for the given text content to appear on the page before taking the
    * screenshot.
    *
-   * If the content does not appear within the worker's timeout, the snap
-   * fails with a clear error so that stale content strings are surfaced
-   * immediately. Set the top-level `failOnWaitForTimeout: false` option in
-   * your Happo config to restore the legacy behavior of warning and
-   * screenshotting whatever is on the page anyway.
+   * When the top-level `failOnWaitForTimeout` option is `true` (the
+   * default), the snap fails with a clear error if the content does not
+   * appear within the worker's timeout, so that stale content strings are
+   * surfaced immediately. When `failOnWaitForTimeout` is `false`, a
+   * timeout only emits a warning in the worker logs and the screenshot is
+   * taken anyway.
    */
   waitForContent?: string;
 
@@ -120,11 +121,12 @@ export interface Page {
    * Wait for an element matching the given selector to appear in the DOM
    * before taking the screenshot.
    *
-   * If the selector is not found within the worker's timeout, the snap
-   * fails with a clear error so that stale selectors are surfaced
-   * immediately. Set the top-level `failOnWaitForTimeout: false` option in
-   * your Happo config to restore the legacy behavior of warning and
-   * screenshotting whatever is on the page anyway.
+   * When the top-level `failOnWaitForTimeout` option is `true` (the
+   * default), the snap fails with a clear error if the selector is not
+   * found within the worker's timeout, so that stale selectors are
+   * surfaced immediately. When `failOnWaitForTimeout` is `false`, a
+   * timeout only emits a warning in the worker logs and the screenshot is
+   * taken anyway.
    */
   waitForSelector?: string;
 }

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { inspect } from 'node:util';
 
 import { any as findAny } from 'empathic/find';
 
@@ -313,8 +314,12 @@ export async function loadConfigFile(
     config.failOnWaitForTimeout !== undefined &&
     typeof config.failOnWaitForTimeout !== 'boolean'
   ) {
+    // Use `util.inspect` rather than `JSON.stringify` so that values which
+    // can't be serialized (BigInts, circular objects, etc.) still produce
+    // the intended "must be a boolean" validation error instead of an
+    // unrelated serialization failure.
     throw new TypeError(
-      `Invalid \`failOnWaitForTimeout\` in config file ${configFilePath}: must be a boolean, got: ${JSON.stringify(config.failOnWaitForTimeout)}.`,
+      `Invalid \`failOnWaitForTimeout\` in config file ${configFilePath}: must be a boolean, got: ${inspect(config.failOnWaitForTimeout)}.`,
     );
   }
 

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -309,6 +309,19 @@ export async function loadConfigFile(
     }
   }
 
+  if (
+    config.failOnWaitForTimeout !== undefined &&
+    typeof config.failOnWaitForTimeout !== 'boolean'
+  ) {
+    throw new TypeError(
+      `Invalid \`failOnWaitForTimeout\` in config file ${configFilePath}: must be a boolean, got: ${JSON.stringify(config.failOnWaitForTimeout)}.`,
+    );
+  }
+
+  if (config.failOnWaitForTimeout === undefined) {
+    config.failOnWaitForTimeout = true;
+  }
+
   const configWithDefaults = {
     endpoint: DEFAULT_ENDPOINT,
     githubApiUrl: 'https://api.github.com',

--- a/src/e2e/__tests__/wrapper.test.ts
+++ b/src/e2e/__tests__/wrapper.test.ts
@@ -19,6 +19,7 @@ const happoConfig = () => ({
   endpoint: `http://localhost:${serverPort}`,
   githubApiUrl: 'https://api.github.com',
   integration: { type: 'playwright' as const },
+  failOnWaitForTimeout: true,
 });
 
 const baseEnvironment = {

--- a/src/e2e/controller.ts
+++ b/src/e2e/controller.ts
@@ -348,6 +348,9 @@ class Controller {
           globalCSS,
           assetsPackage: assetsPath,
           snapPayloads: snapshotsForTarget,
+          ...(this.happoConfig.failOnWaitForTimeout === undefined
+            ? {}
+            : { failOnWaitForTimeout: this.happoConfig.failOnWaitForTimeout }),
         },
         this.happoConfig,
       );

--- a/src/e2e/controller.ts
+++ b/src/e2e/controller.ts
@@ -348,9 +348,7 @@ class Controller {
           globalCSS,
           assetsPackage: assetsPath,
           snapPayloads: snapshotsForTarget,
-          ...(this.happoConfig.failOnWaitForTimeout === undefined
-            ? {}
-            : { failOnWaitForTimeout: this.happoConfig.failOnWaitForTimeout }),
+          failOnWaitForTimeout: this.happoConfig.failOnWaitForTimeout,
         },
         this.happoConfig,
       );

--- a/src/network/__tests__/cancelJob.test.ts
+++ b/src/network/__tests__/cancelJob.test.ts
@@ -47,6 +47,7 @@ beforeEach(async () => {
         entryPoint: 'index.js',
       }),
     },
+    failOnWaitForTimeout: true,
   };
 
   environment = {

--- a/src/network/__tests__/createAsyncComparison.test.ts
+++ b/src/network/__tests__/createAsyncComparison.test.ts
@@ -55,6 +55,7 @@ beforeEach(async () => {
     integration: {
       type: 'storybook',
     },
+    failOnWaitForTimeout: true,
   };
 
   environment = {

--- a/src/network/__tests__/createExtendsReportSnapRequest.test.ts
+++ b/src/network/__tests__/createExtendsReportSnapRequest.test.ts
@@ -36,6 +36,7 @@ beforeEach(async () => {
     project: 'test-project',
     targets: {},
     integration: { type: 'storybook' },
+    failOnWaitForTimeout: true,
   };
 
   makeHappoAPIRequestImpl = async () => ({ requestId: 42 });

--- a/src/network/__tests__/findBaselineReport.test.ts
+++ b/src/network/__tests__/findBaselineReport.test.ts
@@ -43,6 +43,7 @@ beforeEach(async () => {
     project: 'test-project',
     targets: {},
     integration: { type: 'storybook' },
+    failOnWaitForTimeout: true,
   };
 
   environment = {

--- a/src/network/__tests__/makeHappoAPIRequest.test.ts
+++ b/src/network/__tests__/makeHappoAPIRequest.test.ts
@@ -136,6 +136,7 @@ beforeEach(() => {
     endpoint: 'http://localhost:8990',
     apiKey: 'foo',
     apiSecret: 'bar',
+    failOnWaitForTimeout: true,
   };
 });
 

--- a/src/network/__tests__/uploadAssets.test.ts
+++ b/src/network/__tests__/uploadAssets.test.ts
@@ -59,6 +59,7 @@ beforeEach(() => {
       type: 'custom',
       build: async () => ({ rootDir: './custom', entryPoint: 'index.js' }),
     },
+    failOnWaitForTimeout: true,
   };
 
   buffer = Buffer.from('test content') as Buffer<ArrayBuffer>;

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -215,11 +215,8 @@ export default async function prepareSnapRequests(
 
       const targetParams: ExecuteParams = {
         targetName: name,
+        failOnWaitForTimeout: config.failOnWaitForTimeout,
       };
-
-      if (config.failOnWaitForTimeout !== undefined) {
-        targetParams.failOnWaitForTimeout = config.failOnWaitForTimeout;
-      }
 
       if (prepareResult) {
         targetParams.staticPackage = prepareResult.packagePath;

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -217,6 +217,10 @@ export default async function prepareSnapRequests(
         targetName: name,
       };
 
+      if (config.failOnWaitForTimeout !== undefined) {
+        targetParams.failOnWaitForTimeout = config.failOnWaitForTimeout;
+      }
+
       if (prepareResult) {
         targetParams.staticPackage = prepareResult.packagePath;
 


### PR DESCRIPTION
## Summary

- Adds a new top-level `failOnWaitForTimeout` config option (boolean, default `true`) that flows into every render request payload (Storybook/static, `pages`, and Cypress/Playwright E2E runs).
- When `true`, a `waitForContent` / `waitForSelector` timeout fails the snap with a clear error. When `false`, the worker preserves the legacy behavior of warning and screenshotting whatever is on the page.
- Validation rejects non-boolean values with a clear error pointing to the config file.

Worker-side support landed in happo/happo-snap#1241. Original incident: HAP-894 — a customer's Storybook had ~20s silent waits because `waitForContent` strings were stale and the worker logs gave nothing to go on.

## ⚠️ Release notes — please call this out specially

This changes default behavior. Runs that have stale `waitForContent` or `waitForSelector` values will start failing instead of silently producing screenshots with a ~20s timeout penalty per snap.

**If you encounter a failure after upgrading:**

1. **Preferred:** update the offending `waitForContent` / `waitForSelector` so it matches what is actually rendered. This is almost always the right fix — it removes both the failure and the wasted wait time.
2. **Last resort:** set `failOnWaitForTimeout: false` in your Happo config to restore the previous warn-and-screenshot behavior while you investigate.

## Test plan

- [x] `pnpm test loadConfig` — validation rejects non-booleans; default is `true`; explicit `false` is preserved
- [x] `pnpm test RemoteBrowserTarget` — option flows into every chunk payload (bulk path); omitted from payload when unset
- [x] `pnpm lint`
- [x] `pnpm build:types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)