### PR TITLE
Drop snapshots from failed Playwright test attempts

### DIFF
--- a/src/playwright/__playwright__/app2.spec.ts
+++ b/src/playwright/__playwright__/app2.spec.ts
@@ -24,3 +24,29 @@ test('basic test', async ({ page, happoScreenshot, double }) => {
     variant: 'inside app2',
   });
 });
+
+test.describe('retry handling', () => {
+  // Force a single retry for the test below so we exercise the failed-attempt
+  // snapshot cleanup added in src/playwright/index.ts.
+  test.describe.configure({ retries: 1 });
+
+  test('drops snapshots registered during a failed attempt', async ({
+    page,
+    happoScreenshot,
+  }, testInfo) => {
+    await page.goto(`http://localhost:${serverInfo.port}/index.html`);
+
+    // Register a snapshot on every attempt. Without the cleanup, the failed
+    // first attempt would leave a "Retry > Body / default" snapshot in the
+    // report and the passing retry would land as "Retry > Body / default-2".
+    await happoScreenshot(page.locator('body'), {
+      component: 'Retry > Body',
+      variant: 'default',
+    });
+
+    // Fail the first attempt only.
+    if (testInfo.retry === 0) {
+      throw new Error('Intentional failure to trigger a Playwright retry');
+    }
+  });
+});

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -80,9 +80,18 @@ export const test: TestType<
   ],
 
   _happoForEachTest: [
-    async ({}, use) => {
+    async ({}, use, testInfo) => {
       specCounter++;
+      const start = Date.now();
       await use();
+      const end = Date.now();
+
+      // If this attempt didn't pass, drop any snapshots it registered so a
+      // retry (or terminal failure) doesn't leave duplicates in the report.
+      if (testInfo.status !== testInfo.expectedStatus) {
+        controller.removeSnapshotsMadeBetween({ start, end });
+      }
+
       if (specCounter % BATCH_SIZE === 0) {
         // Send batch of 4 screenshots to Happo
         await controller.finish();
@@ -181,6 +190,7 @@ export const test: TestType<
 
       await controller.registerSnapshot({
         ...snapshot,
+        timestamp: Date.now(),
         component,
         variant,
         ...rest,


### PR DESCRIPTION
## Summary

- When a Playwright test fails and Playwright retries it, the `happoScreenshot` calls from the failed attempt previously stayed in the controller's buffer. Both attempts would end up reaching happo.io and the duplicate would be renamed with a `-2` suffix (e.g. `Sign in` and `Sign in-2`).
- The Cypress integration has handled this since v6.0.0 (logic carried over from `happo-cypress` in a661d60). Playwright had no equivalent.
- This change mirrors the Cypress approach: `_happoForEachTest` now records the time bracket around `use()` and calls `controller.removeSnapshotsMadeBetween` when `testInfo.status !== testInfo.expectedStatus`. `registerSnapshot` now also stamps a `timestamp` on the snapshot — the cleanup helper short-circuits on entries with no timestamp, so this was required for the filter to actually run.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build:types` passes
- [x] `pnpm test:playwright` — the new `retry handling` describe block in `src/playwright/__playwright__/app2.spec.ts` forces one retry, calls `happoScreenshot` on both attempts, and throws on the first. Verify the resulting Happo report contains exactly one `Retry > Body / default` snapshot (no `-2` duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)