### PR TITLE
Throw on malformed inline dynamic targets in e2e Controller

### DIFF
--- a/src/e2e/__tests__/controller.test.ts
+++ b/src/e2e/__tests__/controller.test.ts
@@ -213,6 +213,46 @@ describe('Controller', () => {
     ]);
   });
 
+  it('registers a snapshot with an inline dynamic target', async () => {
+    const controller = new Controller();
+    await controller.init();
+
+    await controller.registerSnapshot({
+      html: '<div>Test</div>',
+      assetUrls: [],
+      component: 'Button',
+      variant: 'primary',
+      cssBlocks: [],
+      targets: [{ name: 'firefox-small', type: 'firefox', viewport: '400x800' }],
+    });
+
+    assert.deepStrictEqual(controller.snapshotsList[0]?.targets, ['firefox-small']);
+    assert.deepStrictEqual(controller.config?.targets['firefox-small'], {
+      viewport: '400x800',
+      type: 'firefox',
+      __dynamic: true,
+    });
+  });
+
+  it('throws when a dynamic target object is missing required fields', async () => {
+    const controller = new Controller();
+    await controller.init();
+
+    await assert.rejects(
+      () =>
+        controller.registerSnapshot({
+          html: '<div>Test</div>',
+          assetUrls: [],
+          component: 'Button',
+          variant: 'primary',
+          cssBlocks: [],
+          // @ts-expect-error: deliberately malformed
+          targets: [{ name: 'firefox-small', browser: 'firefox', viewport: '400x800' }],
+        }),
+      /Invalid dynamic target: missing required field\(s\) `type`.*`browser`\/`browserType` field was renamed to `type`/s,
+    );
+  });
+
   it('init() returns false and finish() is a no-op when happo is disabled (no HAPPO_E2E_PORT)', async () => {
     const savedPort = process.env.HAPPO_E2E_PORT;
     delete process.env.HAPPO_E2E_PORT;

--- a/src/e2e/controller.ts
+++ b/src/e2e/controller.ts
@@ -505,33 +505,43 @@ class Controller {
     for (const target of targets) {
       if (typeof target === 'string') {
         result.push(target);
+        continue;
       }
 
-      if (
-        typeof target === 'object' &&
-        target.name &&
-        target.viewport &&
-        target.type
-      ) {
-        if (!this.happoConfig) {
-          throw new Error('Happo config not initialized');
-        }
-
-        if (this.happoConfig.targets[target.name]) {
-          // already added
-        } else {
-          const targetName = target.name;
-          const constructedTarget: TargetWithDefaults = {
-            viewport: target.viewport,
-            type: target.type,
-            __dynamic: true,
-          };
-          // add dynamic target
-          this.happoConfig.targets[targetName] = constructedTarget;
-        }
-
-        result.push(target.name);
+      if (typeof target !== 'object' || target === null) {
+        throw new TypeError(
+          `Invalid target: expected a string or an object of the form { name, viewport, type }. Received ${typeof target}: ${JSON.stringify(target)}`,
+        );
       }
+
+      const missing: Array<string> = [];
+      if (!target.name) missing.push('name');
+      if (!target.viewport) missing.push('viewport');
+      if (!target.type) missing.push('type');
+
+      if (missing.length > 0) {
+        const received = Object.keys(target);
+        const hint =
+          'browserType' in target || 'browser' in target
+            ? ' (the `browser`/`browserType` field was renamed to `type`)'
+            : '';
+        throw new Error(
+          `Invalid dynamic target: missing required field(s) ${missing
+            .map((m) => `\`${m}\``)
+            .join(', ')}${hint}. Received fields: [${received.join(', ')}]. Full value: ${JSON.stringify(target)}`,
+        );
+      }
+
+      if (!this.happoConfig.targets[target.name]) {
+        const constructedTarget: TargetWithDefaults = {
+          viewport: target.viewport,
+          type: target.type,
+          __dynamic: true,
+        };
+        this.happoConfig.targets[target.name] = constructedTarget;
+      }
+
+      result.push(target.name);
     }
 
     return result;

--- a/src/e2e/controller.ts
+++ b/src/e2e/controller.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { inspect } from 'node:util';
 
 import limitConcur from 'limit-concur';
 
@@ -509,8 +510,12 @@ class Controller {
       }
 
       if (typeof target !== 'object' || target === null) {
+        // Use `util.inspect` rather than `JSON.stringify` so that values which
+        // can't be serialized (BigInts, circular objects, etc.) still produce
+        // the intended validation error instead of an unrelated serialization
+        // failure.
         throw new TypeError(
-          `Invalid target: expected a string or an object of the form { name, viewport, type }. Received ${typeof target}: ${JSON.stringify(target)}`,
+          `Invalid target: expected a string or an object of the form { name, viewport, type }. Received ${typeof target}: ${inspect(target)}`,
         );
       }
 
@@ -528,7 +533,7 @@ class Controller {
         throw new Error(
           `Invalid dynamic target: missing required field(s) ${missing
             .map((m) => `\`${m}\``)
-            .join(', ')}${hint}. Received fields: [${received.join(', ')}]. Full value: ${JSON.stringify(target)}`,
+            .join(', ')}${hint}. Received fields: [${received.join(', ')}]. Full value: ${inspect(target)}`,
         );
       }
 

--- a/src/playwright/__playwright__/app.spec.ts
+++ b/src/playwright/__playwright__/app.spec.ts
@@ -34,7 +34,7 @@ test('basic test', async ({ page, happoScreenshot }) => {
     variant: 'default',
     targets: [
       'chrome',
-      { name: 'firefox-small', browser: 'firefox', viewport: '400x800' },
+      { name: 'firefox-small', type: 'firefox', viewport: '400x800' },
     ],
   });
 


### PR DESCRIPTION
## Summary

- Fixes a bug where `happoScreenshot` calls with custom inline targets were silently dropped when the target object failed validation (e.g. using the legacy `browser` / `browserType` field instead of `type`).
- `handleDynamicTargets` now throws a descriptive error listing the missing field(s), with a special hint when `browser` / `browserType` is present.
- Fixes the playwright test fixture, which was using the stale `browser` field and was passing only because of the silent drop.

## Why

Reported by a user upgrading from the legacy happo packages: snapshots referencing custom browser targets vanished without any error, leaving them with no way to debug it. The validator in `handleDynamicTargets` required `target.type`, but on mismatch it just skipped the object. The snapshot then ended up with `targets: []`, and the filter in `finish()` treats `[]` differently from `undefined` — so the snapshot was excluded from every configured target and never sent.

## Test plan

- [x] `pnpm test` — 387 pass / 0 fail
- [x] `pnpm lint`
- [x] `pnpm build:types`
- [x] New unit tests cover the happy-path inline dynamic target and the error message for the malformed-target case

🤖 Generated with [Claude Code](https://claude.com/claude-code)