### PR TITLE
Support Storybook v8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           happo-api-key: ${{ secrets.HAPPO_API_KEY }}
           happo-api-secret: ${{ secrets.HAPPO_API_SECRET }}
-          projects: 'cypress,storybook-v9,storybook-v10,storybook-skipped,storybook-only,playwright,playwright-nonce,custom,custom-skipped,pages'
+          projects: 'cypress,storybook-v8,storybook-v9,storybook-v10,storybook-skipped,storybook-only,playwright,playwright-nonce,custom,custom-skipped,pages'
 
   cypress:
     runs-on: ubuntu-latest
@@ -74,6 +74,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-env
       - run: pnpm test:pages
+
+  storybook-v8:
+    runs-on: ubuntu-latest
+    name: Storybook v8
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-env
+      - run: pnpm add -D storybook@8 @storybook/builder-vite@8 @storybook/react-vite@8
+      - run: pnpm test:storybook:v8
 
   storybook:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-env
-      - run: pnpm add -D storybook@8 @storybook/builder-vite@8 @storybook/react-vite@8
+      - run: pnpm add -D storybook@8 @storybook/react@8 @storybook/builder-vite@8 @storybook/react-vite@8
       - run: pnpm test:storybook:v8
 
   storybook:

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,6 +17,7 @@ const config: Config = defineConfig(
       '.claude/**',
       '.happo-out/**',
       '.out/**',
+      '.out-v8/**',
       'coverage/**',
       'dist/**',
       'playwright-report/**',

--- a/happoconfigs/happo.storybook-v8.config.ts
+++ b/happoconfigs/happo.storybook-v8.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from '../src/config/index.ts';
+import { defineConfig } from '../src/config/index.ts';
+import baseConfig from './happo.config.ts';
+
+const config: Config = defineConfig({
+  ...baseConfig,
+  project: 'storybook-v8',
+  integration: {
+    type: 'storybook',
+    configDir: 'src/storybook/__tests__/storybook-app-v8',
+  },
+});
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test:playwright": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright.config.ts e2e -- playwright test",
     "test:playwright:nonce": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE e2e -- playwright test && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.playwright-nonce.config.ts --nonce $HAPPO_NONCE finalize",
     "test:storybook": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts",
+    "test:storybook:v8": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook-v8.config.ts",
     "test:storybook:skipped": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-skipped --skip \"$(node ./scripts/getSkip.ts)\"",
     "test:storybook:only": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.storybook.config.ts --project storybook-only --only \"$(node ./scripts/getOnly.ts)\"",
     "test:pages": "pnpm build:dist && node --env-file-if-exists=.env.local dist/cli/main.js -c ./happoconfigs/happo.pages.config.ts",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -43,6 +43,7 @@ const DIST_CONFIGS: Array<EntryConfig> = [
   {
     entryPoints: [
       'src/storybook/browser/addon.ts',
+      'src/storybook/browser/addon-v8.ts',
       'src/storybook/browser/decorator.ts',
       'src/storybook/browser/register.ts',
     ],

--- a/src/storybook/__tests__/index-v8.test.ts
+++ b/src/storybook/__tests__/index-v8.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { before, describe, it } from 'node:test';
+
+import happoStorybookPlugin from '../index.ts';
+
+// Stories in storybook-app-v8:
+//   Simple: Basic, Excluded, Themed  → 3 story entries in index.json
+const TOTAL_STORIES = 3;
+
+describe('happoStorybookPlugin (v8-compatible app)', () => {
+  let packageDir: string;
+  let estimatedSnapsCount: number | undefined;
+
+  before(async () => {
+    ({ packageDir, estimatedSnapsCount } = await happoStorybookPlugin({
+      configDir: 'src/storybook/__tests__/storybook-app-v8',
+      outputDir: '.out-v8',
+    }));
+  });
+
+  it('removes project.json after build', () => {
+    assert.strictEqual(fs.existsSync(path.join(packageDir, 'project.json')), false);
+  });
+
+  it('returns estimatedSnapsCount from index.json', () => {
+    assert.strictEqual(estimatedSnapsCount, TOTAL_STORIES);
+  });
+});

--- a/src/storybook/__tests__/storybook-app-v8/Simple.stories.ts
+++ b/src/storybook/__tests__/storybook-app-v8/Simple.stories.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+
+import Button from './src/Button.ts';
+
+export default {
+  title: 'Simple',
+};
+
+export const Basic = {
+  render: (): ReactNode => createElement(Button, { label: 'Click me' }),
+};
+
+export const Excluded = {
+  render: (): ReactNode => createElement('div', null, 'not in happo'),
+  parameters: { happo: false },
+};
+
+export const Themed = {
+  render: (): ReactNode =>
+    createElement('div', { style: { color: 'currentColor' } }, 'themed text'),
+  parameters: {
+    happo: { themes: ['light', 'dark'] as const },
+  },
+};

--- a/src/storybook/__tests__/storybook-app-v8/main.ts
+++ b/src/storybook/__tests__/storybook-app-v8/main.ts
@@ -1,0 +1,21 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+// Minimal Storybook config compatible with v8, v9, and v10.
+// Intentionally avoids 'storybook/actions' and 'storybook/test', which did
+// not exist as storybook package exports in Storybook v8.
+const result: StorybookConfig = {
+  stories: ['./**/*.stories.ts'],
+
+  addons: ['../../preset.ts'],
+
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+
+  typescript: {
+    check: false,
+  },
+};
+
+export default result;

--- a/src/storybook/__tests__/storybook-app-v8/preview.ts
+++ b/src/storybook/__tests__/storybook-app-v8/preview.ts
@@ -1,5 +1,6 @@
 import type { Decorator } from '@storybook/react-vite';
 
 import happoDecorator from '../../browser/decorator.ts';
+import '../../browser/register.ts';
 
 export const decorators: Array<Decorator> = [happoDecorator];

--- a/src/storybook/__tests__/storybook-app-v8/preview.ts
+++ b/src/storybook/__tests__/storybook-app-v8/preview.ts
@@ -1,0 +1,5 @@
+import type { Decorator } from '@storybook/react-vite';
+
+import happoDecorator from '../../browser/decorator.ts';
+
+export const decorators: Array<Decorator> = [happoDecorator];

--- a/src/storybook/__tests__/storybook-app-v8/preview.ts
+++ b/src/storybook/__tests__/storybook-app-v8/preview.ts
@@ -1,6 +1,7 @@
+import '../../browser/register.ts';
+
 import type { Decorator } from '@storybook/react-vite';
 
 import happoDecorator from '../../browser/decorator.ts';
-import '../../browser/register.ts';
 
 export const decorators: Array<Decorator> = [happoDecorator];

--- a/src/storybook/__tests__/storybook-app-v8/src/Button.ts
+++ b/src/storybook/__tests__/storybook-app-v8/src/Button.ts
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+
+interface ButtonProps {
+  label: string;
+}
+
+export default function Button({ label }: ButtonProps): ReactNode {
+  return createElement(
+    'button',
+    {
+      style: {
+        fontSize: '1em',
+        padding: '8px 16px',
+        color: 'white',
+        backgroundColor: 'steelblue',
+        border: 'none',
+        borderRadius: 4,
+      },
+    },
+    label,
+  );
+}

--- a/src/storybook/browser/addon-v8.ts
+++ b/src/storybook/browser/addon-v8.ts
@@ -1,3 +1,9 @@
+// NOTE: This file is intentionally duplicated as addon.ts. The two files
+// are identical except for the manager-api import path: Storybook v8 exposes
+// it at 'storybook/internal/manager-api' while v9+ use 'storybook/manager-api'.
+// No single path works across all three major versions (v8/v9/v10), and the
+// React hooks used here can't be cleanly injected to share an implementation,
+// so the duplication is kept explicit. Keep the two files in sync.
 import { createElement, useEffect, useState } from 'react';
 import { AddonPanel } from 'storybook/internal/components';
 import {

--- a/src/storybook/browser/addon-v8.ts
+++ b/src/storybook/browser/addon-v8.ts
@@ -1,0 +1,108 @@
+import { createElement, useEffect, useState } from 'react';
+import { AddonPanel } from 'storybook/internal/components';
+import {
+  addons,
+  types,
+  useChannel,
+  useParameter,
+  useStorybookState,
+} from 'storybook/internal/manager-api';
+
+const ADDON_ID = 'happo';
+const PANEL_ID = `${ADDON_ID}/panel`;
+
+interface FunctionParam {
+  key: string;
+}
+
+function HappoPanel() {
+  const happoParams = useParameter('happo', null);
+  const state = useStorybookState();
+  const emit = useChannel({});
+  const [functionParams, setFunctionParams] = useState<Array<FunctionParam>>([]);
+
+  useEffect(() => {
+    function listen(event: { params: Array<FunctionParam> }) {
+      setFunctionParams(event.params);
+    }
+
+    addons.getChannel().on('happo/functions/params', listen);
+
+    return () => {
+      addons.getChannel().off('happo/functions/params', listen);
+    };
+  }, [state.storyId]);
+
+  return createElement(
+    'div',
+    {
+      style: {
+        padding: 10,
+        fontSize: 12,
+      },
+    },
+    happoParams
+      ? createElement(
+          'table',
+          null,
+          createElement(
+            'tbody',
+            null,
+            Object.keys(happoParams).map((key) => {
+              const val = happoParams[key];
+
+              return createElement(
+                'tr',
+                { key: key },
+                createElement('td', null, createElement('code', null, `${key}:`)),
+                createElement(
+                  'td',
+                  null,
+                  createElement('code', null, JSON.stringify(val)),
+                ),
+              );
+            }),
+            functionParams.map((param) => {
+              return createElement(
+                'tr',
+                { key: param.key },
+                createElement(
+                  'td',
+                  null,
+                  createElement('code', null, `${param.key}:`),
+                ),
+                createElement(
+                  'td',
+                  null,
+                  createElement(
+                    'button',
+                    {
+                      onClick: () =>
+                        emit('happo/functions/invoke', {
+                          storyId: state.storyId,
+                          funcName: param.key,
+                        }),
+                    },
+                    'Invoke',
+                  ),
+                ),
+              );
+            }),
+          ),
+        )
+      : createElement('div', null, 'No happo params for this story'),
+  );
+}
+
+addons.register(ADDON_ID, () => {
+  addons.add(PANEL_ID, {
+    type: types.PANEL,
+    title: 'Happo',
+    render: ({ active }) => {
+      return createElement(AddonPanel, {
+        active: active ?? false,
+        children: createElement(HappoPanel, null),
+      });
+    },
+  });
+});

--- a/src/storybook/browser/addon.ts
+++ b/src/storybook/browser/addon.ts
@@ -1,3 +1,9 @@
+// NOTE: This file is intentionally duplicated as addon-v8.ts. The two files
+// are identical except for the manager-api import path: Storybook v8 exposes
+// it at 'storybook/internal/manager-api' while v9+ use 'storybook/manager-api'.
+// No single path works across all three major versions (v8/v9/v10), and the
+// React hooks used here can't be cleanly injected to share an implementation,
+// so the duplication is kept explicit. Keep the two files in sync.
 import { createElement, useEffect, useState } from 'react';
 import { AddonPanel } from 'storybook/internal/components';
 import {

--- a/src/storybook/browser/decorator.ts
+++ b/src/storybook/browser/decorator.ts
@@ -1,5 +1,5 @@
 import { createElement, type ReactNode, useEffect } from 'react';
-import { addons, makeDecorator } from 'storybook/preview-api';
+import { addons, makeDecorator } from 'storybook/internal/preview-api';
 
 import { SB_ROOT_ELEMENT_SELECTOR } from './constants.ts';
 

--- a/src/storybook/browser/storybook-manager-api-compat.d.ts
+++ b/src/storybook/browser/storybook-manager-api-compat.d.ts
@@ -1,0 +1,7 @@
+// 'storybook/internal/manager-api' existed in Storybook v8 and v9 but was
+// removed in v10. This ambient declaration lets addon-v8.ts compile against
+// the v10 dev install; at runtime the import resolves from the user's v8
+// Storybook install where the path actually exists.
+declare module 'storybook/internal/manager-api' {
+  export * from 'storybook/manager-api';
+}

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -14,9 +14,9 @@ const { HAPPO_DEBUG } = process.env;
 function resolveBuildCommandParts() {
   const version = getStorybookVersionFromPackageJson();
 
-  if (version < 9) {
+  if (version < 8) {
     throw new Error(
-      `Storybook v${version} is not supported. Please update storybook to v9 or later.`,
+      `Storybook v${version} is not supported. Please update storybook to v8 or later.`,
     );
   }
 

--- a/src/storybook/preset.ts
+++ b/src/storybook/preset.ts
@@ -1,10 +1,17 @@
 import path from 'node:path';
 
+import getStorybookVersionFromPackageJson from './getStorybookVersionFromPackageJson.ts';
+
 // Support both CJS (Storybook v9) and ESM (Storybook v10)
 const dirname = typeof __dirname === 'undefined' ? import.meta.dirname : __dirname;
 
 export function managerEntries(entry: Array<string> = []): Array<string> {
-  return [...entry, path.resolve(dirname, './browser/addon.js')];
+  // Storybook v8 exposes manager APIs via 'storybook/internal/manager-api';
+  // v9 and v10 use 'storybook/manager-api'. The two addon bundles import from
+  // the appropriate path so we select the right one here.
+  const version = getStorybookVersionFromPackageJson();
+  const addonFile = version < 9 ? './browser/addon-v8.js' : './browser/addon.js';
+  return [...entry, path.resolve(dirname, addonFile)];
 }
 
 export function config(entry: Array<string> = []): Array<string> {


### PR DESCRIPTION
## Summary

- **Lower version guard** from v9 to v8 in `src/storybook/index.ts`
- **Fix `decorator.ts`** — switch from `storybook/preview-api` to `storybook/internal/preview-api`, which exists in v8, v9, and v10 with identical exports (single codepath, no branching needed)
- **Fix addon/manager panel** — `storybook/manager-api` exists in v9/v10 but not v8; `storybook/internal/manager-api` exists in v8/v9 but not v10. No single path covers all three, so `preset.ts` now reads the installed version and returns `addon-v8.js` (importing from `storybook/internal/manager-api`) for v8 or the existing `addon.js` for v9+
- **New v8-compatible test fixture** (`src/storybook/__tests__/storybook-app-v8/`) — avoids `storybook/actions` and `storybook/test`, which are not exported by the `storybook` package in v8; builds cleanly with any installed Storybook version
- **CI**: new `storybook-v8` job that downgrades packages to v8 and runs `pnpm test:storybook:v8`; `storybook-v8` added to the orchestrate-happo projects list

## How the manager-api split was discovered

Probing the Storybook manager's globals maps across versions:

| Import path | v8 globals | v9 globals | v10 globals |
|---|---|---|---|
| `storybook/manager-api` | ❌ | ✅ | ✅ |
| `storybook/internal/manager-api` | ✅ | ✅ | ❌ |

The manager bundler only provides modules listed in its globals map as runtime variables — anything else would need to be bundled, and since these paths don't exist in the wrong versions that would fail. Two entry points with the preset selecting the right one is the cleanest fix.

## Test plan

- [ ] `pnpm build` — clean
- [ ] `pnpm test` — all pass (includes new `index-v8.test.ts` that builds the v8 fixture)
- [ ] `pnpm lint` — clean
- [ ] CI `storybook-v8` job passes with real Storybook v8 installed