### PR TITLE
Set pnpm minimumReleaseAge to 2 days to match Dependabot

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,10 @@ autoInstallPeers: true
 savePrefix: ''
 dedupePeerDependents: true
 
-# Bypass the default 1-day minimumReleaseAge for packages we publish
-# ourselves, so we can install fresh versions immediately after release.
+# Match dependabot npm cooldown (default-days: 2 in .github/dependabot.yml)
+minimumReleaseAge: 2880
+
+# Bypass minimumReleaseAge for packages we publish ourselves, so we can
+# install fresh versions immediately after release.
 minimumReleaseAgeExclude:
   - release-with-ease


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge` to 2880 minutes (2 days) in `pnpm-workspace.yaml` to align with Dependabot npm cooldown.
- Keeps existing `minimumReleaseAgeExclude` for `release-with-ease`.

## Test plan
- [ ] `pnpm install` succeeds

Made with [Cursor](https://cursor.com)