### PR TITLE
Fix API key/secret leak in e2e CLI logging

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -528,8 +528,10 @@ async function handleFinalizeCommand(
   logger: Logger,
 ): Promise<void> {
   logger.log('Finalizing happo report...');
-  logger.log('Config:', config);
-  logger.log('Environment:', environment);
+  if (environment.debugMode) {
+    logger.log('Config:', config);
+    logger.log('Environment:', environment);
+  }
 
   try {
     const finalizeAll = (await import('../e2e/wrapper.ts')).finalizeAll;
@@ -632,9 +634,11 @@ async function handleE2ECommand(
   }
 
   logger.log('Setting up happo wrapper for Cypress and Playwright...');
-  logger.log('Config:', config);
-  logger.log('Environment:', environment);
-  logger.log('Dashdash command parts:', dashdashCommandParts);
+  if (environment.debugMode) {
+    logger.log('Config:', config);
+    logger.log('Environment:', environment);
+    logger.log('Dashdash command parts:', dashdashCommandParts);
+  }
 
   const runWithWrapper = (await import('../e2e/wrapper.ts')).default;
   const exitCode = await runWithWrapper(


### PR DESCRIPTION
## What changed

`handleE2ECommand` and `handleFinalizeCommand` in [`src/cli/index.ts`](src/cli/index.ts) were unconditionally calling `logger.log('Config:', config)`, printing the fully-resolved config object — including `apiKey`/`apiSecret` (sourced from `HAPPO_API_KEY`/`HAPPO_API_SECRET`) — to stdout. This runs on every invocation of the `e2e` and `finalize` commands, which power the Cypress and Playwright integrations, so credentials were showing up in CI logs.

This fixes it by gating the `Config:`/`Environment:`/`Dashdash command parts:` debug logs behind `environment.debugMode` (set via the `HAPPO_DEBUG` env var), matching the existing debug-logging convention already used elsewhere in the codebase (`src/environment/index.ts`, `src/e2e/controller.ts`, `src/storybook/index.ts`, etc.). The non-sensitive status messages ("Setting up happo wrapper...", "Finalizing happo report...") remain unconditional.

## Why

We shouldn't print these in logs. See the two call sites this touches:
- `handleE2ECommand`: previously unconditional log at what was `src/cli/index.ts#L633-L637`
- `handleFinalizeCommand`: same unconditional log pattern a few lines earlier

## Notes for reviewer

- With `HAPPO_DEBUG=true` set, the full config (including credentials) is still logged intentionally — this matches how debug mode already behaves elsewhere in the CLI (e.g. `resolveEnvironment` dumps the raw env in debug mode too), and is what the reporting customer asked for as the escape hatch.
- Verified: `pnpm build:types`, `pnpm lint`, and `pnpm test cli/index` (39/39 passing) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)