### PR TITLE
Improve the message Happo shows when a run fails

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -866,9 +866,7 @@ describe('main', () => {
       });
 
       it('sends skip in the finalize request body when --skippedExamples is set', async () => {
-        const skip = [
-          { component: 'Button', variant: 'primary', target: 'chrome' },
-        ];
+        const skip = [{ component: 'Button', variant: 'primary', target: 'chrome' }];
         await main(
           [
             'npx',
@@ -891,8 +889,7 @@ describe('main', () => {
         );
         assert.ok(finalizeCall, 'expected a finalize API call');
         assert.deepStrictEqual(
-          (finalizeCall.arguments[0]?.body as { skip: unknown })
-            ?.skip,
+          (finalizeCall.arguments[0]?.body as { skip: unknown })?.skip,
           skip,
         );
       });
@@ -918,16 +915,32 @@ describe('main', () => {
         );
         assert.ok(finalizeCall, 'expected a finalize API call');
         assert.deepStrictEqual(
-          (finalizeCall.arguments[0]?.body as { skip: unknown })
-            ?.skip,
+          (finalizeCall.arguments[0]?.body as { skip: unknown })?.skip,
           [],
         );
       });
 
       describe('cancelling the Happo job', () => {
+        // The cancel message depends on whether we are running in CI and on
+        // whether we can resolve a CI job URL, so clear everything the
+        // environment module reads for those. Empty strings rather than
+        // `undefined` because assigning to `process.env` stringifies values,
+        // which would turn `undefined` into a truthy `'undefined'`.
         withOverrides(
           () => process.env,
-          () => ({}),
+          () => ({
+            BUILD_BUILDID: '',
+            CI: '',
+            CIRCLE_BUILD_URL: '',
+            GITHUB_REPOSITORY: '',
+            GITHUB_RUN_ATTEMPT: '',
+            GITHUB_RUN_ID: '',
+            GITHUB_SERVER_URL: '',
+            SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: '',
+            SYSTEM_TEAMPROJECT: '',
+            TRAVIS_BUILD_WEB_URL: '',
+            TRAVIS_JOB_WEB_URL: '',
+          }),
         );
 
         it('cancels the Happo job when the command fails', async () => {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -960,9 +960,21 @@ describe('main', () => {
             cancelRequest.arguments[0]?.path,
             '/api/jobs/foobar/barfoo/cancel',
           );
-          assert.strictEqual(
-            (cancelRequest.arguments[0]?.body as { message: string })?.message,
-            'cypress run failed',
+          const { message } = cancelRequest.arguments[0]?.body as {
+            message: string;
+          };
+          // Happo only keeps the first line of the message.
+          assert.doesNotMatch(message, /[\r\n]/);
+          // The exit code from `ls` differs between platforms, and the temp
+          // directory path is long enough that the command gets truncated, so
+          // we only check the shape of the message.
+          assert.match(
+            message,
+            /^Cypress run failed: "ls .+" exited with code \d+\./,
+          );
+          assert.match(
+            message,
+            /Review the happo command output in your terminal for the full details\.$/,
           );
         });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -339,13 +339,17 @@ async function handleDefaultCommand(
 ): Promise<void> {
   logger.log('Running happo tests...');
 
-  const [startJob, createAsyncComparison, createAsyncReport, prepareSnapRequests] =
-    await Promise.all([
-      (await import('../network/startJob.ts')).default,
-      (await import('../network/createAsyncComparison.ts')).default,
-      (await import('../network/createAsyncReport.ts')).default,
-      (await import('../network/prepareSnapRequests.ts')).default,
-    ]);
+  const [
+    { default: startJob },
+    { default: createAsyncComparison },
+    { default: createAsyncReport },
+    { default: prepareSnapRequests },
+  ] = await Promise.all([
+    import('../network/startJob.ts'),
+    import('../network/createAsyncComparison.ts'),
+    import('../network/createAsyncReport.ts'),
+    import('../network/prepareSnapRequests.ts'),
+  ]);
 
   // Tell Happo that we are about to run a job
   await startJob(config, environment, logger);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -426,9 +426,8 @@ async function handleDefaultCommand(
       // Find a baseline to borrow the excluded stories from, unless --skip
       // already resolved one.
       if (!baselineSha) {
-        const findBaselineReport = (
-          await import('../network/findBaselineReport.ts')
-        ).default;
+        const findBaselineReport = (await import('../network/findBaselineReport.ts'))
+          .default;
         baselineSha = await findBaselineReport(environment, config, logger);
       }
 
@@ -515,8 +514,21 @@ async function handleDefaultCommand(
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     logger.error(`${config.integration.type} run failed: ${message}`, e);
-    const cancelJob = (await import('../network/cancelJob.ts')).default;
-    await cancelJob('failure', message, config, environment, logger);
+    const [cancelJob, formatFailureMessage] = await Promise.all([
+      (await import('../network/cancelJob.ts')).default,
+      (await import('../network/formatFailureMessage.ts')).default,
+    ]);
+    await cancelJob(
+      'failure',
+      formatFailureMessage({
+        integrationType: config.integration.type,
+        error: message,
+        environment,
+      }),
+      config,
+      environment,
+      logger,
+    );
     process.exitCode = 1;
     return;
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -388,9 +388,8 @@ async function handleDefaultCommand(
         return;
       }
 
-      const findBaselineReport = (
-        await import('../network/findBaselineReport.ts')
-      ).default;
+      const findBaselineReport = (await import('../network/findBaselineReport.ts'))
+        .default;
       baselineSha = await findBaselineReport(environment, config, logger);
       if (!baselineSha) {
         logger.log(
@@ -448,7 +447,11 @@ async function handleDefaultCommand(
     // Prepare the snap requests for the job. This includes bundling static
     // assets and uploading them. Only pass the skip list when we have a
     // baseline to borrow the skipped examples from.
-    const { snapRequestIds, resolvedSkip } = await prepareSnapRequests(config, skip, only);
+    const { snapRequestIds, resolvedSkip } = await prepareSnapRequests(
+      config,
+      skip,
+      only,
+    );
 
     let allSnapRequestIds = snapRequestIds;
 
@@ -514,10 +517,11 @@ async function handleDefaultCommand(
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     logger.error(`${config.integration.type} run failed: ${message}`, e);
-    const [cancelJob, formatFailureMessage] = await Promise.all([
-      (await import('../network/cancelJob.ts')).default,
-      (await import('../network/formatFailureMessage.ts')).default,
-    ]);
+    const [{ default: cancelJob }, { default: formatFailureMessage }] =
+      await Promise.all([
+        import('../network/cancelJob.ts'),
+        import('../network/formatFailureMessage.ts'),
+      ]);
     await cancelJob(
       'failure',
       formatFailureMessage({

--- a/src/e2e/__tests__/wrapper.test.ts
+++ b/src/e2e/__tests__/wrapper.test.ts
@@ -34,6 +34,7 @@ const baseEnvironment = {
   fallbackShas: undefined,
   githubToken: undefined,
   ci: false,
+  ciJobUrl: undefined,
   skip: undefined,
   only: undefined,
 };

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -243,10 +243,7 @@ export default async function runWithWrapper(
   // Write skipped examples to a temp file to avoid env var size limits.
   let skipFilePath: string | undefined;
   if (skipJSON) {
-    skipFilePath = path.join(
-      os.tmpdir(),
-      `happo-skipped-${process.pid}.json`,
-    );
+    skipFilePath = path.join(os.tmpdir(), `happo-skipped-${process.pid}.json`);
     await fs.promises.writeFile(skipFilePath, skipJSON, 'utf8');
   }
 
@@ -276,39 +273,49 @@ export default async function runWithWrapper(
 
       const e2eIntegration = happoConfig.integration;
       assertE2EIntegration(e2eIntegration);
-      child.on('close', async (code: number) => {
-        if (code === 0 || e2eIntegration.allowFailures) {
-          try {
-            await finalizeHappoReport(happoConfig, environment, job, logger);
-          } catch (e) {
-            logger.error('Failed to finalize Happo report', e);
-            return reject(e);
-          }
-        } else {
-          logger.error(
-            `[HAPPO] Command failed with exit code ${code}: ${dashdashCommandParts.join(' ')}. Cancelling Happo job. See the output above for details about the failure.`,
-          );
-          try {
-            await cancelJob(
-              'failure',
-              formatFailureMessage({
-                integrationType: e2eIntegration.type,
-                command: dashdashCommandParts,
-                // `code` is null when the command was killed by a signal.
-                exitCode: code ?? undefined,
-                environment,
-              }),
-              happoConfig,
-              environment,
-              logger,
+      // `code` is null when the command was terminated by a signal, in which
+      // case `signal` says which one.
+      child.on(
+        'close',
+        async (code: number | null, signal: NodeJS.Signals | null) => {
+          if (code === 0 || e2eIntegration.allowFailures) {
+            try {
+              await finalizeHappoReport(happoConfig, environment, job, logger);
+            } catch (e) {
+              logger.error('Failed to finalize Happo report', e);
+              return reject(e);
+            }
+          } else {
+            const reason =
+              code === null
+                ? `was terminated by ${signal ?? 'a signal'}`
+                : `failed with exit code ${code}`;
+            logger.error(
+              `[HAPPO] Command ${reason}: ${dashdashCommandParts.join(' ')}. Cancelling Happo job. See the output above for details about the failure.`,
             );
-          } catch (e) {
-            logger.error('Failed to cancel Happo job', e);
-            return reject(e);
+            try {
+              await cancelJob(
+                'failure',
+                formatFailureMessage({
+                  integrationType: e2eIntegration.type,
+                  command: dashdashCommandParts,
+                  exitCode: code ?? undefined,
+                  environment,
+                }),
+                happoConfig,
+                environment,
+                logger,
+              );
+            } catch (e) {
+              logger.error('Failed to cancel Happo job', e);
+              return reject(e);
+            }
           }
-        }
-        resolve(code);
-      });
+          // A signal-terminated command has no exit code of its own, but it
+          // still needs to fail the happo run.
+          resolve(code ?? 1);
+        },
+      );
     });
     return exitCode;
   } finally {

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -8,6 +8,7 @@ import type { ConfigWithDefaults, E2EIntegration } from '../config/index.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
 import cancelJob from '../network/cancelJob.ts';
 import createAsyncComparison from '../network/createAsyncComparison.ts';
+import formatFailureMessage from '../network/formatFailureMessage.ts';
 import makeHappoAPIRequest from '../network/makeHappoAPIRequest.ts';
 import postGitHubComment from '../network/postGitHubComment.ts';
 import startJob, { type StartJobResult } from '../network/startJob.ts';
@@ -285,12 +286,18 @@ export default async function runWithWrapper(
           }
         } else {
           logger.error(
-            'Command failed with exit code ${code}. Cancelling Happo job.',
+            `[HAPPO] Command failed with exit code ${code}: ${dashdashCommandParts.join(' ')}. Cancelling Happo job. See the output above for details about the failure.`,
           );
           try {
             await cancelJob(
               'failure',
-              `${e2eIntegration.type} run failed`,
+              formatFailureMessage({
+                integrationType: e2eIntegration.type,
+                command: dashdashCommandParts,
+                // `code` is null when the command was killed by a signal.
+                exitCode: code ?? undefined,
+                environment,
+              }),
               happoConfig,
               environment,
               logger,

--- a/src/environment/__tests__/index.test.ts
+++ b/src/environment/__tests__/index.test.ts
@@ -667,6 +667,80 @@ describe('resolveEnvironment', () => {
     assert.equal(result.skip, undefined);
   });
 
+  describe('ciJobUrl', () => {
+    it('is undefined when not running in a known CI environment', async () => {
+      initGitRepo();
+      const result = await resolveEnvironment({}, {});
+      assert.equal(result.ciJobUrl, undefined);
+    });
+
+    it('resolves a GitHub Actions run URL', async () => {
+      initGitRepo();
+      const result = await resolveEnvironment(
+        {},
+        {
+          GITHUB_SERVER_URL: 'https://github.com',
+          GITHUB_REPOSITORY: 'happo/happo',
+          GITHUB_RUN_ID: '123',
+          GITHUB_RUN_ATTEMPT: '2',
+        },
+      );
+      assert.equal(
+        result.ciJobUrl,
+        'https://github.com/happo/happo/actions/runs/123/attempts/2',
+      );
+    });
+
+    it('defaults the GitHub server URL and omits the attempt when unknown', async () => {
+      initGitRepo();
+      const result = await resolveEnvironment(
+        {},
+        { GITHUB_REPOSITORY: 'happo/happo', GITHUB_RUN_ID: '123' },
+      );
+      assert.equal(
+        result.ciJobUrl,
+        'https://github.com/happo/happo/actions/runs/123',
+      );
+    });
+
+    it('resolves a CircleCI build URL', async () => {
+      initGitRepo();
+      const result = await resolveEnvironment(
+        {},
+        { CIRCLE_BUILD_URL: 'https://circleci.com/gh/happo/happo/456' },
+      );
+      assert.equal(result.ciJobUrl, 'https://circleci.com/gh/happo/happo/456');
+    });
+
+    it('prefers the Travis job URL over the build URL', async () => {
+      initGitRepo();
+      const result = await resolveEnvironment(
+        {},
+        {
+          TRAVIS_BUILD_WEB_URL: 'https://travis-ci.com/happo/happo/builds/1',
+          TRAVIS_JOB_WEB_URL: 'https://travis-ci.com/happo/happo/jobs/2',
+        },
+      );
+      assert.equal(result.ciJobUrl, 'https://travis-ci.com/happo/happo/jobs/2');
+    });
+
+    it('resolves an Azure Pipelines build URL', async () => {
+      initGitRepo();
+      const result = await resolveEnvironment(
+        {},
+        {
+          SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: 'https://dev.azure.com/happo/',
+          SYSTEM_TEAMPROJECT: 'happo',
+          BUILD_BUILDID: '789',
+        },
+      );
+      assert.equal(
+        result.ciJobUrl,
+        'https://dev.azure.com/happo/happo/_build/results?buildId=789',
+      );
+    });
+  });
+
   it('rejects if the link is not a valid URL', async () => {
     const link = 'not a url';
 

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -20,20 +20,16 @@ interface GitHubEvent {
       sha: string;
     };
   };
-  head_commit?:
-    | {
-        url: string;
-        message?: string;
-      }
-    | null;
+  head_commit?: {
+    url: string;
+    message?: string;
+  } | null;
   merge_group?: {
     head_sha: string;
     base_sha: string;
-    head_commit?:
-      | {
-          message?: string;
-        }
-      | null;
+    head_commit?: {
+      message?: string;
+    } | null;
   };
   repository?: {
     html_url: string;
@@ -240,7 +236,9 @@ function resolveCIJobUrl(
   } = env;
 
   if (GITHUB_REPOSITORY && GITHUB_RUN_ID) {
-    const serverUrl = GITHUB_SERVER_URL || 'https://github.com';
+    // Enterprise setups sometimes configure the server URL with a trailing
+    // slash, which would double up with the one we add below.
+    const serverUrl = (GITHUB_SERVER_URL || 'https://github.com').replace(/\/$/, '');
     const runUrl = `${serverUrl}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
     return GITHUB_RUN_ATTEMPT ? `${runUrl}/attempts/${GITHUB_RUN_ATTEMPT}` : runUrl;
   }

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -56,18 +56,24 @@ export interface EnvironmentResult {
   fallbackShas: Array<string> | undefined;
   githubToken: string | undefined;
   ci: boolean;
+  ciJobUrl: string | undefined;
   skip: string | undefined;
   only: string | undefined;
 }
 
 const envKeys: ReadonlyArray<string> = [
+  'BUILD_BUILDID',
   'BUILD_REPOSITORY_URI',
   'BUILD_SOURCEVERSION',
+  'CIRCLE_BUILD_URL',
   'CIRCLE_PROJECT_REPONAME',
   'CIRCLE_PROJECT_USERNAME',
   'CIRCLE_SHA1',
   'CI_PULL_REQUEST',
   'GITHUB_EVENT_PATH',
+  'GITHUB_REPOSITORY',
+  'GITHUB_RUN_ATTEMPT',
+  'GITHUB_RUN_ID',
   'GITHUB_SERVER_URL',
   'GITHUB_SHA',
   'HAPPO_DEBUG',
@@ -75,8 +81,12 @@ const envKeys: ReadonlyArray<string> = [
   'SYSTEM_PULLREQUEST_SOURCEBRANCH',
   'SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI',
   'SYSTEM_PULLREQUEST_TARGETBRANCH',
+  'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI',
+  'SYSTEM_TEAMPROJECT',
+  'TRAVIS_BUILD_WEB_URL',
   'TRAVIS_COMMIT',
   'TRAVIS_COMMIT_RANGE',
+  'TRAVIS_JOB_WEB_URL',
   'TRAVIS_PULL_REQUEST',
   'TRAVIS_PULL_REQUEST_SHA',
   'TRAVIS_REPO_SLUG',
@@ -197,6 +207,55 @@ async function resolveLink(
 
   if (CIRCLE_PROJECT_USERNAME && CIRCLE_PROJECT_REPONAME && CIRCLE_SHA1) {
     return `${githubBase}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve a URL pointing at the logs for the CI job we are running in. This is
+ * used to point developers at the full output when something goes wrong.
+ */
+function resolveCIJobUrl(
+  env: Record<string, string | undefined>,
+): string | undefined {
+  const {
+    // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables
+    BUILD_BUILDID,
+    SYSTEM_TEAMFOUNDATIONCOLLECTIONURI,
+    SYSTEM_TEAMPROJECT,
+
+    // https://circleci.com/docs/reference/variables/
+    CIRCLE_BUILD_URL,
+
+    // https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
+    GITHUB_REPOSITORY,
+    GITHUB_RUN_ATTEMPT,
+    GITHUB_RUN_ID,
+    GITHUB_SERVER_URL,
+
+    // https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+    TRAVIS_BUILD_WEB_URL,
+    TRAVIS_JOB_WEB_URL,
+  } = env;
+
+  if (GITHUB_REPOSITORY && GITHUB_RUN_ID) {
+    const serverUrl = GITHUB_SERVER_URL || 'https://github.com';
+    const runUrl = `${serverUrl}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+    return GITHUB_RUN_ATTEMPT ? `${runUrl}/attempts/${GITHUB_RUN_ATTEMPT}` : runUrl;
+  }
+
+  if (CIRCLE_BUILD_URL) {
+    return CIRCLE_BUILD_URL;
+  }
+
+  if (TRAVIS_JOB_WEB_URL || TRAVIS_BUILD_WEB_URL) {
+    return TRAVIS_JOB_WEB_URL || TRAVIS_BUILD_WEB_URL;
+  }
+
+  if (SYSTEM_TEAMFOUNDATIONCOLLECTIONURI && SYSTEM_TEAMPROJECT && BUILD_BUILDID) {
+    const collectionUri = SYSTEM_TEAMFOUNDATIONCOLLECTIONURI.replace(/\/$/, '');
+    return `${collectionUri}/${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}`;
   }
 
   return undefined;
@@ -674,6 +733,7 @@ export default async function resolveEnvironment(
     fallbackShas: resolveFallbackShas(cliArgs, nonNullBeforeSha),
     githubToken: cliArgs.githubToken,
     ci: !!env.CI,
+    ciJobUrl: resolveCIJobUrl(env),
     skip: cliArgs.skip,
     only: cliArgs.only,
   };

--- a/src/network/__tests__/cancelJob.test.ts
+++ b/src/network/__tests__/cancelJob.test.ts
@@ -62,6 +62,7 @@ beforeEach(async () => {
     fallbackShas: ['test-sha'],
     githubToken: 'test-token',
     ci: false,
+    ciJobUrl: undefined,
     skip: undefined,
     only: undefined,
   };

--- a/src/network/__tests__/createAsyncComparison.test.ts
+++ b/src/network/__tests__/createAsyncComparison.test.ts
@@ -67,6 +67,7 @@ beforeEach(async () => {
     notify: undefined,
     fallbackShas: undefined,
     ci: false,
+    ciJobUrl: undefined,
     nonce: undefined,
     githubToken: undefined,
     debugMode: false,

--- a/src/network/__tests__/findBaselineReport.test.ts
+++ b/src/network/__tests__/findBaselineReport.test.ts
@@ -58,6 +58,7 @@ beforeEach(async () => {
     fallbackShas: ['fallback-sha-1', 'fallback-sha-2'],
     githubToken: undefined,
     ci: false,
+    ciJobUrl: undefined,
     skip: undefined,
     only: undefined,
   };

--- a/src/network/__tests__/formatFailureMessage.test.ts
+++ b/src/network/__tests__/formatFailureMessage.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import formatFailureMessage from '../formatFailureMessage.ts';
+
+const localEnvironment = { ci: false, ciJobUrl: undefined };
+const ciEnvironment = { ci: true, ciJobUrl: undefined };
+
+describe('formatFailureMessage', () => {
+  it('explains what failed and where to look', () => {
+    const message = formatFailureMessage({
+      integrationType: 'playwright',
+      command: ['npx', 'playwright', 'test'],
+      exitCode: 1,
+      environment: {
+        ci: true,
+        ciJobUrl: 'https://github.com/happo/happo/actions/runs/123',
+      },
+    });
+
+    assert.strictEqual(
+      message,
+      'Playwright run failed: "npx playwright test" exited with code 1. Review the logs from your CI job for the full output: https://github.com/happo/happo/actions/runs/123',
+    );
+  });
+
+  it('includes the error when there is one', () => {
+    const message = formatFailureMessage({
+      integrationType: 'storybook',
+      error: 'Failed to finalize assets',
+      environment: ciEnvironment,
+    });
+
+    assert.strictEqual(
+      message,
+      'Storybook run failed: Failed to finalize assets. Review the logs from your CI job for the full output.',
+    );
+  });
+
+  it('points at the terminal when not running in CI', () => {
+    const message = formatFailureMessage({
+      integrationType: 'cypress',
+      environment: localEnvironment,
+    });
+
+    assert.strictEqual(
+      message,
+      'Cypress run failed. Review the happo command output in your terminal for the full details.',
+    );
+  });
+
+  it('says the command did not complete when it was killed by a signal', () => {
+    const message = formatFailureMessage({
+      integrationType: 'cypress',
+      command: ['yarn', 'cypress', 'run'],
+      exitCode: undefined,
+      environment: ciEnvironment,
+    });
+
+    assert.match(message, /"yarn cypress run" did not complete\./);
+    assert.doesNotMatch(message, /exited with code/);
+  });
+
+  // Happo drops everything after the first newline, so a multi-line error must
+  // not be able to swallow the rest of the message.
+  it('is always a single line', () => {
+    const message = formatFailureMessage({
+      integrationType: 'storybook',
+      error: 'Failed to build\n  at doThing (thing.js:1:1)\n  at other (o.js:2:2)',
+      environment: ciEnvironment,
+    });
+
+    assert.doesNotMatch(message, /[\r\n]/);
+    assert.strictEqual(
+      message,
+      'Storybook run failed: Failed to build at doThing (thing.js:1:1) at other (o.js:2:2). Review the logs from your CI job for the full output.',
+    );
+  });
+
+  it('truncates long errors and commands', () => {
+    const message = formatFailureMessage({
+      integrationType: 'storybook',
+      command: ['npx', 'some-very-long-command'.repeat(10)],
+      error: 'a'.repeat(600),
+      environment: ciEnvironment,
+    });
+
+    assert.match(message, /"npx some-very-long-command.{0,60}…" did not complete/);
+    // The ellipsis stands in for the sentence-ending period.
+    assert.match(message, /: a{119}… Review/);
+  });
+
+  it('keeps the whole CI job url, however long the failure details are', () => {
+    const ciJobUrl =
+      'https://github.enterprise.acme-corporation.com/platform-team/frontend-monorepo/actions/runs/12345678901/attempts/2';
+    const message = formatFailureMessage({
+      integrationType: 'playwright',
+      command: ['npx', 'playwright', 'test'],
+      exitCode: 1,
+      error: 'a'.repeat(600),
+      environment: { ci: true, ciJobUrl },
+    });
+
+    assert.ok(message.endsWith(ciJobUrl), `url was cut short: ${message}`);
+  });
+
+  it('does not add a second period when the error ends with one', () => {
+    const message = formatFailureMessage({
+      integrationType: 'storybook',
+      error: 'Something went wrong.',
+      environment: ciEnvironment,
+    });
+
+    assert.match(message, /Something went wrong\. Review/);
+  });
+
+  it('ignores empty errors and commands', () => {
+    const message = formatFailureMessage({
+      integrationType: 'storybook',
+      error: '   ',
+      command: [],
+      environment: ciEnvironment,
+    });
+
+    assert.strictEqual(
+      message,
+      'Storybook run failed. Review the logs from your CI job for the full output.',
+    );
+  });
+});

--- a/src/network/formatFailureMessage.ts
+++ b/src/network/formatFailureMessage.ts
@@ -1,0 +1,100 @@
+import type { EnvironmentResult } from '../environment/index.ts';
+
+// Happo keeps only the *first line* of this message and caps it at 1000
+// characters, so the message has to be a single line — anything after a
+// newline is dropped, including newlines inside the error we interpolate. It
+// is rendered as plain text, and URLs in it are auto-linked on the job page,
+// so the CI job link goes last where it is easy to spot and can't be cut
+// short by a long error.
+const MAX_ERROR_LENGTH = 120;
+const MAX_COMMAND_LENGTH = 80;
+
+export interface FailureMessageOptions {
+  /** The integration that was running, e.g. 'playwright' or 'storybook'. */
+  integrationType: string;
+
+  /** The command that failed, when the failure came from a spawned command. */
+  command?: Array<string> | undefined;
+
+  /** The exit code of the failed command, when it exited on its own. */
+  exitCode?: number | undefined;
+
+  /** The error that caused the failure, when we caught one. */
+  error?: string | undefined;
+
+  environment: Pick<EnvironmentResult, 'ci' | 'ciJobUrl'>;
+}
+
+function toSingleLine(value: string): string {
+  return value.replaceAll(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+/**
+ * Describe the failure itself: the command that failed and/or the error we
+ * caught. Both are truncated so that a long stack trace or a long command
+ * cannot crowd out the rest of the message.
+ */
+function buildDetail({
+  command,
+  exitCode,
+  error,
+}: Pick<FailureMessageOptions, 'command' | 'exitCode' | 'error'>): string {
+  const parts: Array<string> = [];
+
+  if (command && command.length > 0) {
+    const commandString = truncate(
+      toSingleLine(command.join(' ')),
+      MAX_COMMAND_LENGTH,
+    );
+    parts.push(
+      exitCode === undefined
+        ? `"${commandString}" did not complete`
+        : `"${commandString}" exited with code ${exitCode}`,
+    );
+  } else if (exitCode !== undefined) {
+    parts.push(`Exited with code ${exitCode}`);
+  }
+
+  const errorText = error ? truncate(toSingleLine(error), MAX_ERROR_LENGTH) : '';
+  if (errorText) {
+    parts.push(errorText);
+  }
+
+  return parts.join(': ');
+}
+
+/**
+ * Build the message we send to Happo when a job has to be cancelled because
+ * something failed locally. This message is often the only thing a developer
+ * sees in Happo, so it needs to say what failed and where to look for the
+ * details.
+ */
+export default function formatFailureMessage({
+  integrationType,
+  command,
+  exitCode,
+  error,
+  environment: { ci, ciJobUrl },
+}: FailureMessageOptions): string {
+  const capitalizedType = `${integrationType.charAt(0).toUpperCase()}${integrationType.slice(1)}`;
+  const detail = buildDetail({ command, exitCode, error });
+  const headline = detail
+    ? `${capitalizedType} run failed: ${detail}`
+    : `${capitalizedType} run failed`;
+  const sentence = /[.!?…]$/.test(headline) ? headline : `${headline}.`;
+
+  if (ciJobUrl) {
+    return `${sentence} Review the logs from your CI job for the full output: ${ciJobUrl}`;
+  }
+
+  return ci
+    ? `${sentence} Review the logs from your CI job for the full output.`
+    : `${sentence} Review the happo command output in your terminal for the full details.`;
+}


### PR DESCRIPTION
## What

When an integration fails, we cancel the Happo job with a message. That message used to be `playwright run failed` (or `cypress run failed`), which tells a developer almost nothing. It now looks like this:

```
Playwright run failed: "npx playwright test" exited with code 1. Review the logs from your CI job for the full output: https://github.com/happo/happo/actions/runs/123
```

```
Storybook run failed: Failed to finalize assets. Review the logs from your CI job for the full output.
```

```
Cypress run failed. Review the happo command output in your terminal for the full details.
```

New `formatFailureMessage` builds these, and both cancel paths use it: the e2e wrapper (Cypress/Playwright) and the default command (Storybook/custom), which previously passed the raw `e.message`.

`EnvironmentResult` gains `ciJobUrl`, resolved from the four CI providers the environment module already supports — GitHub Actions, CircleCI, Travis, Azure Pipelines. It is `undefined` elsewhere, and the message still points at the CI logs, just without a link.

## Why the format is what it is

Two constraints from happo-view, worth knowing before anyone reformats this:

- The cancel endpoint runs the message through `normalizeCommitMessage`, which **keeps only the first line** and caps the length at 1000 characters. So the message is a single line, and whitespace inside the interpolated error is collapsed — otherwise a multi-line error (anything stack-ish) would truncate the message at its own first newline and drop the guidance entirely.
- It is rendered as plain text — the "Changes" column on the job page (where URLs are auto-linked, so a bare URL is clickable), a cell in the GitHub PR comment table, and, for single-project jobs, the GitHub commit status description. The CI job link goes last so a long error can't push it out of the string.

The error is capped at 120 characters and the command at 80, both with an ellipsis, so neither can crowd out the rest of the message.

One consequence to be aware of: happo-view slices the commit status description at 140 characters, so on a single-project job with a long error the URL falls past that cut *in that surface only*. The stored message is intact, so the job page and the PR comment both show the full link.

## Also here

The e2e wrapper's "command failed" log line was a single-quoted string containing `${code}`, so it printed the literal text instead of the exit code. It now interpolates the code and names the command.

## Testing

`pnpm test` — 404 pass, 1 pre-existing skip. `pnpm lint` and `pnpm build:types` clean. New unit tests cover the message formatter (including the single-line guarantee and the untouched URL) and `ciJobUrl` resolution per provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
