### PR TITLE
Borrow skipped examples via extends-report in the e2e flow

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -18,6 +18,7 @@ interface Logger {
 let logger: Logger;
 let main: (argv: Array<string>, logger: Logger) => Promise<void>;
 let flakeResponseOverride: object | null = null;
+let findBaselineResponseOverride: object | null = null;
 const makeHappoAPIRequestMock: Mock<typeof makeHappoAPIRequest> = mock.fn(
   async (request: RequestAttributes, config: ConfigWithDefaults) => {
     const { url, path } = request;
@@ -30,6 +31,10 @@ const makeHappoAPIRequestMock: Mock<typeof makeHappoAPIRequest> = mock.fn(
 
     if (fetchURL.includes('/api/jobs')) {
       return { id: 99, url: 'https://happo.io/api/jobs/99' };
+    }
+
+    if (fetchURL.includes('/find-baseline')) {
+      return findBaselineResponseOverride ?? { sha: 'baseline-sha' };
     }
 
     if (fetchURL.includes('/api/snap-requests/bulk')) {
@@ -162,6 +167,7 @@ beforeEach(async () => {
   });
 
   makeHappoAPIRequestMock.mock.resetCalls();
+  findBaselineResponseOverride = null;
   postGitHubCommentMock.mock.resetCalls();
 });
 
@@ -865,8 +871,8 @@ describe('main', () => {
         assert(makeHappoAPIRequestMock.mock.callCount() > 0);
       });
 
-      it('sends skip in the finalize request body when --skippedExamples is set', async () => {
-        const skip = [{ component: 'Button', variant: 'primary', target: 'chrome' }];
+      it('borrows skipped examples from the baseline via an extends-report when --skippedExamples is set', async () => {
+        const skip = [{ component: 'Button', variant: 'primary' }];
         await main(
           [
             'npx',
@@ -875,7 +881,7 @@ describe('main', () => {
             '--afterSha',
             'test-sha',
             '--beforeSha',
-            'test-sha',
+            'before-sha',
             '--nonce',
             'test-nonce',
             '--skippedExamples',
@@ -884,17 +890,54 @@ describe('main', () => {
           logger,
         );
         assert.equal(process.exitCode, 0);
+
+        const extendsCall = makeHappoAPIRequestMock.mock.calls.find((call) =>
+          call.arguments[0]?.path?.includes('/snap-requests/extends-report'),
+        );
+        assert.ok(extendsCall, 'expected an extends-report API call');
+        const extendsBody = extendsCall.arguments[0]?.body as {
+          extendsSha: string;
+          extendedSnaps: unknown;
+        };
+        assert.strictEqual(extendsBody.extendsSha, 'baseline-sha');
+        assert.deepStrictEqual(extendsBody.extendedSnaps, skip);
+
+        // The extends-report request has to be attached to the nonced async
+        // report before it is finalized, or it will not be part of the report.
+        const attachCall = makeHappoAPIRequestMock.mock.calls.find(
+          (call) =>
+            call.arguments[0]?.path === '/api/async-reports/test-sha' &&
+            (call.arguments[0]?.body as { requestIds?: Array<number> })
+              ?.requestIds?.length,
+        );
+        assert.ok(attachCall, 'expected the extends-report to be attached');
+        assert.deepStrictEqual(
+          (attachCall.arguments[0]?.body as { requestIds: Array<number> })
+            .requestIds,
+          [123],
+        );
+        assert.strictEqual(
+          (attachCall.arguments[0]?.body as { nonce: string }).nonce,
+          'test-nonce',
+        );
+
         const finalizeCall = makeHappoAPIRequestMock.mock.calls.find((call) =>
           call.arguments[0]?.path?.includes('/finalize'),
         );
         assert.ok(finalizeCall, 'expected a finalize API call');
-        assert.deepStrictEqual(
-          (finalizeCall.arguments[0]?.body as { skip: unknown })?.skip,
-          skip,
+        // The old placeholder mechanism is gone — sending both would duplicate
+        // the borrowed snapshots.
+        assert.ok(
+          !('skippedExamples' in (finalizeCall.arguments[0]?.body as object)),
+          'finalize body should not carry skippedExamples',
+        );
+        assert.ok(
+          !('skip' in (finalizeCall.arguments[0]?.body as object)),
+          'finalize body should not carry skip',
         );
       });
 
-      it('sends an empty skip array when --skippedExamples is not set', async () => {
+      it('does not create an extends-report when --skippedExamples is not set', async () => {
         await main(
           [
             'npx',
@@ -903,20 +946,69 @@ describe('main', () => {
             '--afterSha',
             'test-sha',
             '--beforeSha',
-            'test-sha',
+            'before-sha',
             '--nonce',
             'test-nonce',
           ],
           logger,
         );
         assert.equal(process.exitCode, 0);
+        const extendsCall = makeHappoAPIRequestMock.mock.calls.find((call) =>
+          call.arguments[0]?.path?.includes('/snap-requests/extends-report'),
+        );
+        assert.strictEqual(extendsCall, undefined);
+      });
+
+      it('finalizes without borrowing when no baseline report is found', async () => {
+        findBaselineResponseOverride = {};
+        await main(
+          [
+            'npx',
+            'happo',
+            'finalize',
+            '--afterSha',
+            'test-sha',
+            '--beforeSha',
+            'before-sha',
+            '--nonce',
+            'test-nonce',
+            '--skippedExamples',
+            JSON.stringify([{ component: 'Button', variant: 'primary' }]),
+          ],
+          logger,
+        );
+        assert.equal(process.exitCode, 0);
+
+        const extendsCall = makeHappoAPIRequestMock.mock.calls.find((call) =>
+          call.arguments[0]?.path?.includes('/snap-requests/extends-report'),
+        );
+        assert.strictEqual(extendsCall, undefined);
+
         const finalizeCall = makeHappoAPIRequestMock.mock.calls.find((call) =>
           call.arguments[0]?.path?.includes('/finalize'),
         );
-        assert.ok(finalizeCall, 'expected a finalize API call');
-        assert.deepStrictEqual(
-          (finalizeCall.arguments[0]?.body as { skip: unknown })?.skip,
-          [],
+        assert.ok(finalizeCall, 'expected a finalize API call anyway');
+      });
+
+      it('rejects storyFile items in --skippedExamples', async () => {
+        await main(
+          [
+            'npx',
+            'happo',
+            'finalize',
+            '--afterSha',
+            'test-sha',
+            '--nonce',
+            'test-nonce',
+            '--skippedExamples',
+            JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+          ],
+          logger,
+        );
+        assert.strictEqual(process.exitCode, 1);
+        assert.match(
+          String(logger.error.mock.calls[0]?.arguments[0]),
+          /storyFile.*not supported/,
         );
       });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1081,6 +1081,29 @@ describe('main', () => {
         );
       });
 
+      it('names --skippedExamples in the validator error, not --skip', async () => {
+        await main(
+          [
+            'npx',
+            'happo',
+            'finalize',
+            '--afterSha',
+            'test-sha',
+            '--nonce',
+            'test-nonce',
+            '--skippedExamples',
+            JSON.stringify([{ nope: true }]),
+          ],
+          logger,
+        );
+        assert.strictEqual(process.exitCode, 1);
+        const message = logger.error.mock.calls
+          .map((c) => c.arguments.join(' '))
+          .join('\n');
+        assert.match(message, /--skippedExamples must be a JSON array/);
+        assert.doesNotMatch(message, /--skip must be a JSON array/);
+      });
+
       it('fails when both --skip and --skippedExamples are given', async () => {
         const skip = JSON.stringify([{ component: 'Button' }]);
         await main(

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -718,6 +718,67 @@ describe('main', () => {
         );
       });
 
+      it('is aliased by --skippedExamples on the default command', async () => {
+        tmpfs.writeFile(
+          'happo.config.ts',
+          `export default {
+            integration: { type: 'storybook' },
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+          };`,
+        );
+
+        // --skippedExamples used to be parsed and then silently dropped here,
+        // producing a full run with no skipping and no error.
+        await main(
+          [
+            'npx',
+            'happo',
+            '--skippedExamples',
+            JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+          ],
+          logger,
+        );
+
+        const storyFileErrors = logger.error.mock.calls.filter((c) =>
+          String(c.arguments[0]).includes('storyFile'),
+        );
+        assert.strictEqual(storyFileErrors.length, 0);
+      });
+
+      it('names the flag the user actually passed in error messages', async () => {
+        tmpfs.writeFile(
+          'happo.config.ts',
+          `export default {
+            integration: {
+              type: 'custom',
+              build: async () => ({
+                rootDir: ${JSON.stringify(tmpfs.fullPath('happo-custom'))},
+                entryPoint: 'bundle.js',
+              }),
+            },
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+          };`,
+        );
+
+        await main(
+          [
+            'npx',
+            'happo',
+            '--skippedExamples',
+            JSON.stringify([{ storyFile: './src/Button.stories.tsx' }]),
+          ],
+          logger,
+        );
+
+        assert.strictEqual(process.exitCode, 1);
+        assert.match(
+          String(logger.error.mock.calls[0]?.arguments[0]),
+          /storyFile items in --skippedExamples/,
+        );
+      });
+
       it('does not log a storyFile error when storyFile items are used with the storybook integration', async () => {
         tmpfs.writeFile(
           'happo.config.ts',
@@ -988,6 +1049,61 @@ describe('main', () => {
           call.arguments[0]?.path?.includes('/finalize'),
         );
         assert.ok(finalizeCall, 'expected a finalize API call anyway');
+      });
+
+      it('accepts --skip as an alias on the finalize command', async () => {
+        const skip = [{ component: 'Button', variant: 'primary' }];
+        await main(
+          [
+            'npx',
+            'happo',
+            'finalize',
+            '--afterSha',
+            'test-sha',
+            '--beforeSha',
+            'before-sha',
+            '--nonce',
+            'test-nonce',
+            '--skip',
+            JSON.stringify(skip),
+          ],
+          logger,
+        );
+        assert.equal(process.exitCode, 0);
+        const extendsCall = makeHappoAPIRequestMock.mock.calls.find((call) =>
+          call.arguments[0]?.path?.includes('/snap-requests/extends-report'),
+        );
+        assert.ok(extendsCall, 'expected an extends-report API call');
+        assert.deepStrictEqual(
+          (extendsCall.arguments[0]?.body as { extendedSnaps: unknown })
+            .extendedSnaps,
+          skip,
+        );
+      });
+
+      it('fails when both --skip and --skippedExamples are given', async () => {
+        const skip = JSON.stringify([{ component: 'Button' }]);
+        await main(
+          [
+            'npx',
+            'happo',
+            'finalize',
+            '--afterSha',
+            'test-sha',
+            '--nonce',
+            'test-nonce',
+            '--skip',
+            skip,
+            '--skippedExamples',
+            skip,
+          ],
+          logger,
+        );
+        assert.strictEqual(process.exitCode, 1);
+        assert.match(
+          String(logger.error.mock.calls[0]?.arguments[0]),
+          /Use either --skip or --skippedExamples, not both/,
+        );
       });
 
       it('rejects storyFile items in --skippedExamples', async () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -129,7 +129,7 @@ Options:
   --notify <emails>     One or more (comma-separated) email addresses to notify with results
   --nonce <nonce>       Nonce to use for Cypress/Playwright comparison
   --githubToken <token> GitHub token to use for posting Happo statuses as comments. Use in combination with the \`githubApiUrl\` configuration option. (default: auto-detected from environment)
-  --skip <json> JSON array of {component, variant} objects to skip and borrow from the nearest baseline report instead. On the finalize command these are the examples that were already skipped during the run. Also available as --skippedExamples (the two are aliases; pass only one)
+  --skip <json> JSON array of {component, variant?} objects to skip and borrow from the nearest baseline report instead (omit variant to skip every variant of the component). On the finalize command these are the examples that were already skipped during the run. Also available as --skippedExamples (the two are aliases; pass only one)
   --only <json> JSON array of {component} or {storyFile} objects to include in this run (all other stories are skipped); only supported for the Storybook integration
 
 Flake command options:
@@ -264,7 +264,7 @@ export async function main(
       if (environment.skip) {
         let skipItems: Array<SkipItem>;
         try {
-          skipItems = validateSkip(environment.skip);
+          skipItems = validateSkip(environment.skip, skipFlag);
         } catch (e) {
           logger.error(
             `[HAPPO] Invalid ${skipFlag}:`,
@@ -297,7 +297,7 @@ export async function main(
       if (environment.skip) {
         let skipItems: Array<SkipItem>;
         try {
-          skipItems = validateSkip(environment.skip);
+          skipItems = validateSkip(environment.skip, skipFlag);
         } catch (e) {
           logger.error(
             `[HAPPO] Invalid ${skipFlag}:`,
@@ -308,7 +308,7 @@ export async function main(
         }
         if (skipItems.some((item) => 'storyFile' in item)) {
           logger.error(
-            `[HAPPO] storyFile items are not supported in ${skipFlag} for the finalize command. Use {component, variant} instead.`,
+            `[HAPPO] storyFile items are not supported in ${skipFlag} for the finalize command. Use {component, variant?} instead.`,
           );
           process.exitCode = 1;
           return;
@@ -409,7 +409,7 @@ async function handleDefaultCommand(
       }
 
       try {
-        skip = validateSkip(environment.skip);
+        skip = validateSkip(environment.skip, skipFlag);
       } catch (e) {
         logger.error(
           `[HAPPO] Invalid ${skipFlag}:`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -133,7 +133,7 @@ Options:
   --only <json> JSON array of {component} or {storyFile} objects to include in this run (all other stories are skipped); only supported for the Storybook integration
 
 Finalize command options:
-  --skippedExamples <json> JSON array of {component, variant, target} objects to skip when finalizing; borrowed from the nearest baseline report
+  --skippedExamples <json> JSON array of {component, variant} objects that were skipped during the run; borrowed from the nearest baseline report
 
 Flake command options:
   --allProjects         List flakes across all projects (default: current project)
@@ -167,7 +167,7 @@ Examples:
 
   happo finalize
   happo finalize --nonce my-unique-nonce
-  happo finalize --skippedExamples '[{"component":"Button","variant":"primary","target":"chrome"}]'
+  happo finalize --skippedExamples '[{"component":"Button","variant":"Primary"}]'
 
   happo flake
   happo flake --allProjects
@@ -251,12 +251,20 @@ export async function main(
     if (args.dashdashCommandParts) {
       let validatedSkipJSON: string | undefined;
       if (environment.skip) {
+        let skipItems: Array<SkipItem>;
         try {
-          validateSkip(environment.skip);
+          skipItems = validateSkip(environment.skip);
         } catch (e) {
           logger.error(
             '[HAPPO] Invalid --skip:',
             e instanceof Error ? e.message : String(e),
+          );
+          process.exitCode = 1;
+          return;
+        }
+        if (skipItems.some((item) => 'storyFile' in item)) {
+          logger.error(
+            `[HAPPO] storyFile items in --skip are only supported for the storybook integration (current integration: '${config.integration.type}')`,
           );
           process.exitCode = 1;
           return;
@@ -275,8 +283,31 @@ export async function main(
     }
 
     if (command === 'finalize') {
-      const finalizeEnvironment = args.values.skippedExamples
-        ? { ...environment, skip: args.values.skippedExamples }
+      const finalizeSkipJSON = args.values.skippedExamples ?? environment.skip;
+
+      if (finalizeSkipJSON) {
+        let skipItems: Array<SkipItem>;
+        try {
+          skipItems = validateSkip(finalizeSkipJSON);
+        } catch (e) {
+          logger.error(
+            '[HAPPO] Invalid --skippedExamples:',
+            e instanceof Error ? e.message : String(e),
+          );
+          process.exitCode = 1;
+          return;
+        }
+        if (skipItems.some((item) => 'storyFile' in item)) {
+          logger.error(
+            '[HAPPO] storyFile items are not supported in --skippedExamples. Use {component, variant} instead.',
+          );
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      const finalizeEnvironment = finalizeSkipJSON
+        ? { ...environment, skip: finalizeSkipJSON }
         : environment;
       await handleFinalizeCommand(config, finalizeEnvironment, logger);
       return;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -129,11 +129,8 @@ Options:
   --notify <emails>     One or more (comma-separated) email addresses to notify with results
   --nonce <nonce>       Nonce to use for Cypress/Playwright comparison
   --githubToken <token> GitHub token to use for posting Happo statuses as comments. Use in combination with the \`githubApiUrl\` configuration option. (default: auto-detected from environment)
-  --skip <json> JSON array of {component, variant} objects to skip in this run and borrow from the nearest baseline report instead
+  --skip <json> JSON array of {component, variant} objects to skip and borrow from the nearest baseline report instead. On the finalize command these are the examples that were already skipped during the run. Also available as --skippedExamples (the two are aliases; pass only one)
   --only <json> JSON array of {component} or {storyFile} objects to include in this run (all other stories are skipped); only supported for the Storybook integration
-
-Finalize command options:
-  --skippedExamples <json> JSON array of {component, variant} objects that were skipped during the run; borrowed from the nearest baseline report
 
 Flake command options:
   --allProjects         List flakes across all projects (default: current project)
@@ -168,6 +165,7 @@ Examples:
   happo finalize
   happo finalize --nonce my-unique-nonce
   happo finalize --skippedExamples '[{"component":"Button","variant":"Primary"}]'
+  happo finalize --skip '[{"component":"Button","variant":"Primary"}]'
 
   happo flake
   happo flake --allProjects
@@ -235,6 +233,19 @@ export async function main(
       return;
     }
 
+    if (args.values.skip !== undefined && args.values.skippedExamples !== undefined) {
+      logger.error(
+        '[HAPPO] Use either --skip or --skippedExamples, not both. They are two names for the same option.',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    // --skip and --skippedExamples are aliases. Report problems using whichever
+    // one the user actually typed.
+    const skipFlag =
+      args.values.skippedExamples === undefined ? '--skip' : '--skippedExamples';
+
     const environment = await resolveEnvironment(args.values);
 
     // Get config file path (use --config if provided, otherwise find default)
@@ -256,7 +267,7 @@ export async function main(
           skipItems = validateSkip(environment.skip);
         } catch (e) {
           logger.error(
-            '[HAPPO] Invalid --skip:',
+            `[HAPPO] Invalid ${skipFlag}:`,
             e instanceof Error ? e.message : String(e),
           );
           process.exitCode = 1;
@@ -264,7 +275,7 @@ export async function main(
         }
         if (skipItems.some((item) => 'storyFile' in item)) {
           logger.error(
-            `[HAPPO] storyFile items in --skip are only supported for the storybook integration (current integration: '${config.integration.type}')`,
+            `[HAPPO] storyFile items in ${skipFlag} are only supported for the storybook integration (current integration: '${config.integration.type}')`,
           );
           process.exitCode = 1;
           return;
@@ -283,15 +294,13 @@ export async function main(
     }
 
     if (command === 'finalize') {
-      const finalizeSkipJSON = args.values.skippedExamples ?? environment.skip;
-
-      if (finalizeSkipJSON) {
+      if (environment.skip) {
         let skipItems: Array<SkipItem>;
         try {
-          skipItems = validateSkip(finalizeSkipJSON);
+          skipItems = validateSkip(environment.skip);
         } catch (e) {
           logger.error(
-            '[HAPPO] Invalid --skippedExamples:',
+            `[HAPPO] Invalid ${skipFlag}:`,
             e instanceof Error ? e.message : String(e),
           );
           process.exitCode = 1;
@@ -299,17 +308,14 @@ export async function main(
         }
         if (skipItems.some((item) => 'storyFile' in item)) {
           logger.error(
-            '[HAPPO] storyFile items are not supported in --skippedExamples. Use {component, variant} instead.',
+            `[HAPPO] storyFile items are not supported in ${skipFlag} for the finalize command. Use {component, variant} instead.`,
           );
           process.exitCode = 1;
           return;
         }
       }
 
-      const finalizeEnvironment = finalizeSkipJSON
-        ? { ...environment, skip: finalizeSkipJSON }
-        : environment;
-      await handleFinalizeCommand(config, finalizeEnvironment, logger);
+      await handleFinalizeCommand(config, environment, logger);
       return;
     }
 
@@ -347,7 +353,7 @@ export async function main(
     }
 
     if (command === undefined) {
-      await handleDefaultCommand(config, environment, logger);
+      await handleDefaultCommand(config, environment, logger, skipFlag);
       return;
     }
 
@@ -367,6 +373,7 @@ async function handleDefaultCommand(
   config: ConfigWithDefaults,
   environment: EnvironmentResult,
   logger: Logger,
+  skipFlag: string,
 ): Promise<void> {
   logger.log('Running happo tests...');
 
@@ -395,7 +402,7 @@ async function handleDefaultCommand(
       const supportedTypes = ['storybook', 'custom'];
       if (!supportedTypes.includes(config.integration.type)) {
         logger.error(
-          `[HAPPO] --skip is not supported for integration type '${config.integration.type}'. Supported types: ${supportedTypes.join(', ')}`,
+          `[HAPPO] ${skipFlag} is not supported for integration type '${config.integration.type}'. Supported types: ${supportedTypes.join(', ')}`,
         );
         process.exitCode = 1;
         return;
@@ -405,7 +412,7 @@ async function handleDefaultCommand(
         skip = validateSkip(environment.skip);
       } catch (e) {
         logger.error(
-          '[HAPPO] Invalid --skip:',
+          `[HAPPO] Invalid ${skipFlag}:`,
           e instanceof Error ? e.message : String(e),
         );
         process.exitCode = 1;
@@ -417,7 +424,7 @@ async function handleDefaultCommand(
         skip.some((item) => 'storyFile' in item)
       ) {
         logger.error(
-          `[HAPPO] storyFile items in --skip are only supported for the storybook integration (current integration: '${config.integration.type}')`,
+          `[HAPPO] storyFile items in ${skipFlag} are only supported for the storybook integration (current integration: '${config.integration.type}')`,
         );
         process.exitCode = 1;
         return;

--- a/src/e2e/__tests__/wrapper.test.ts
+++ b/src/e2e/__tests__/wrapper.test.ts
@@ -11,6 +11,8 @@ const AFTER_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2';
 let server: http.Server;
 let serverPort: number;
 let comparisonEndpointHits: number;
+let requests: Array<{ url: string; body: unknown }>;
+let baselineSha: string | null;
 
 const happoConfig = () => ({
   apiKey: 'test-key',
@@ -46,6 +48,35 @@ before(async () => {
       // would otherwise keep the event loop alive and hang the test process.
       res.setHeader('Connection', 'close');
       res.setHeader('Content-Type', 'application/json');
+
+      const chunks: Array<Buffer> = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        const raw = Buffer.concat(chunks).toString();
+        let body: unknown;
+        try {
+          body = raw ? JSON.parse(raw) : undefined;
+        } catch {
+          body = raw;
+        }
+        requests.push({ url: req.url ?? '', body });
+      });
+
+      if (req.url?.match(/\/find-baseline$/)) {
+        if (!baselineSha) {
+          // The real API 404s when there is no baseline report.
+          res.statusCode = 404;
+          res.end(JSON.stringify({ error: 'No baseline report found' }));
+          return;
+        }
+        res.end(JSON.stringify({ sha: baselineSha }));
+        return;
+      }
+
+      if (req.url?.match(/^\/api\/snap-requests\/extends-report/)) {
+        res.end(JSON.stringify({ requestId: 4242 }));
+        return;
+      }
 
       if (req.url?.match(/^\/api\/jobs\//)) {
         res.end(
@@ -89,6 +120,8 @@ after(() => {
 
 beforeEach(() => {
   comparisonEndpointHits = 0;
+  requests = [];
+  baselineSha = 'baseline-sha';
 });
 
 // Script that POSTs one snap request ID to the e2e server then exits.
@@ -127,6 +160,113 @@ describe('runWithWrapper', () => {
         'happo.config.js',
       );
       assert.equal(comparisonEndpointHits, 0);
+    },
+  );
+
+  it(
+    'borrows skipped examples from the baseline via an extends-report',
+    { timeout: 5000 },
+    async () => {
+      const skip = [{ component: 'Button', variant: 'Primary' }];
+      await runWithWrapper(
+        childCommand,
+        happoConfig(),
+        baseEnvironment,
+        console,
+        'happo.config.js',
+        JSON.stringify(skip),
+      );
+
+      const extendsRequest = requests.find((r) =>
+        r.url.includes('/snap-requests/extends-report'),
+      );
+      assert.ok(extendsRequest, 'expected an extends-report request');
+      assert.deepStrictEqual(
+        (extendsRequest.body as { extendedSnaps: unknown }).extendedSnaps,
+        skip,
+      );
+      assert.strictEqual(
+        (extendsRequest.body as { extendsSha: string }).extendsSha,
+        'baseline-sha',
+      );
+
+      // Without a nonce the async report is finalized by this POST, so the
+      // extends-report id has to be included in it.
+      const reportRequest = requests.find(
+        (r) => r.url === `/api/async-reports/${AFTER_SHA}`,
+      );
+      assert.ok(reportRequest, 'expected an async report request');
+      assert.ok(
+        (reportRequest.body as { requestIds: Array<number> }).requestIds.includes(
+          4242,
+        ),
+        'expected the extends-report id in the async report',
+      );
+    },
+  );
+
+  it(
+    'does not create an extends-report when there is no skip list',
+    { timeout: 5000 },
+    async () => {
+      await runWithWrapper(
+        childCommand,
+        happoConfig(),
+        baseEnvironment,
+        console,
+        'happo.config.js',
+      );
+
+      assert.strictEqual(
+        requests.find((r) => r.url.includes('/extends-report')),
+        undefined,
+      );
+    },
+  );
+
+  it(
+    'still posts the report when no baseline is found',
+    { timeout: 5000 },
+    async () => {
+      baselineSha = null;
+      await runWithWrapper(
+        childCommand,
+        happoConfig(),
+        baseEnvironment,
+        console,
+        'happo.config.js',
+        JSON.stringify([{ component: 'Button', variant: 'Primary' }]),
+      );
+
+      assert.strictEqual(
+        requests.find((r) => r.url.includes('/extends-report')),
+        undefined,
+      );
+      assert.ok(
+        requests.find((r) => r.url === `/api/async-reports/${AFTER_SHA}`),
+        'expected an async report request anyway',
+      );
+    },
+  );
+
+  it(
+    'does not borrow when a nonce is set (the finalize call does it instead)',
+    { timeout: 5000 },
+    async () => {
+      const environment = { ...baseEnvironment, nonce: 'test-nonce' };
+      await runWithWrapper(
+        childCommand,
+        happoConfig(),
+        environment,
+        console,
+        'happo.config.js',
+        JSON.stringify([{ component: 'Button', variant: 'Primary' }]),
+      );
+
+      assert.strictEqual(
+        requests.find((r) => r.url.includes('/extends-report')),
+        undefined,
+      );
     },
   );
 });

--- a/src/e2e/__tests__/wrapper.test.ts
+++ b/src/e2e/__tests__/wrapper.test.ts
@@ -250,6 +250,28 @@ describe('runWithWrapper', () => {
   );
 
   it(
+    'rejects an invalid skip list before starting the e2e server or job',
+    { timeout: 5000 },
+    async () => {
+      await assert.rejects(
+        runWithWrapper(
+          childCommand,
+          happoConfig(),
+          baseEnvironment,
+          console,
+          'happo.config.js',
+          '[{"nope":true}]',
+        ),
+        /must be a JSON array/,
+      );
+
+      // Nothing external should have been created, so there is no listening
+      // server left behind and no job to cancel.
+      assert.deepStrictEqual(requests, []);
+    },
+  );
+
+  it(
     'does not borrow when a nonce is set (the finalize call does it instead)',
     { timeout: 5000 },
     async () => {

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -64,9 +64,12 @@ export async function finalizeAll({
   if (skipJSON) {
     let skip: Array<SkipItem>;
     try {
-      skip = validateSkip(skipJSON);
+      skip = validateSkip(skipJSON, '--skippedExamples');
     } catch (e) {
-      logger.error('[HAPPO] Invalid --skippedExamples', skipJSON);
+      logger.error(
+        '[HAPPO] Invalid --skippedExamples:',
+        e instanceof Error ? e.message : String(e),
+      );
       throw e;
     }
 
@@ -262,6 +265,14 @@ export default async function runWithWrapper(
   skipJSON?: string,
 ): Promise<number> {
   allRequestIds = new Set<number>();
+
+  // Validate before starting the e2e server or creating the job, so that a
+  // malformed skip list doesn't leave a listening server and an uncancelled
+  // job behind.
+  const skip: Array<SkipItem> | undefined = skipJSON
+    ? validateSkip(skipJSON)
+    : undefined;
+
   const e2eServer = await startE2EServer(environment, happoConfig);
   logger.log(`[HAPPO] Listening on port ${e2eServer.port}`);
 
@@ -272,9 +283,7 @@ export default async function runWithWrapper(
 
   // Write skipped examples to a temp file to avoid env var size limits.
   let skipFilePath: string | undefined;
-  let skip: Array<SkipItem> | undefined;
   if (skipJSON) {
-    skip = validateSkip(skipJSON);
     skipFilePath = path.join(os.tmpdir(), `happo-skipped-${process.pid}.json`);
     await fs.promises.writeFile(skipFilePath, skipJSON, 'utf8');
   }

--- a/src/e2e/wrapper.ts
+++ b/src/e2e/wrapper.ts
@@ -6,8 +6,11 @@ import path from 'node:path';
 
 import type { ConfigWithDefaults, E2EIntegration } from '../config/index.ts';
 import type { EnvironmentResult } from '../environment/index.ts';
+import { validateSkip } from '../isomorphic/parseSkip.ts';
+import type { SkipItem } from '../isomorphic/types.ts';
 import cancelJob from '../network/cancelJob.ts';
 import createAsyncComparison from '../network/createAsyncComparison.ts';
+import createSkipExtendsRequest from '../network/createSkipExtendsRequest.ts';
 import formatFailureMessage from '../network/formatFailureMessage.ts';
 import makeHappoAPIRequest from '../network/makeHappoAPIRequest.ts';
 import postGitHubComment from '../network/postGitHubComment.ts';
@@ -39,12 +42,6 @@ async function postAsyncReport(
   );
 }
 
-type Example = {
-  component: string;
-  variant: string;
-  target: string;
-};
-
 type Logger = Pick<Console, 'log' | 'error'>;
 
 interface FinalizeAllOptions {
@@ -64,30 +61,39 @@ export async function finalizeAll({
     throw new Error('[HAPPO] Missing --nonce argument');
   }
 
-  const body: {
-    project?: string | undefined;
-    nonce: string;
-    skip: Array<Example>;
-  } = {
-    project: happoConfig.project,
-    nonce,
-    skip: [],
-  };
-
   if (skipJSON) {
+    let skip: Array<SkipItem>;
     try {
-      const skipItems = JSON.parse(skipJSON);
-      body.skip = skipItems;
+      skip = validateSkip(skipJSON);
     } catch (e) {
-      logger.error('Error when parsing --skip', skipJSON);
+      logger.error('[HAPPO] Invalid --skippedExamples', skipJSON);
       throw e;
     }
+
+    // Borrow the skipped examples from the baseline via an extends-report,
+    // the same way the storybook/custom integrations do for --skip. The
+    // request is attached to the async report (keyed by nonce) before we
+    // finalize, so that the report is complete by the time it is built.
+    const extendsRequestId = await createSkipExtendsRequest(
+      skip,
+      happoConfig,
+      environment,
+      logger,
+    );
+
+    if (extendsRequestId !== undefined) {
+      await postAsyncReport([extendsRequestId], environment, happoConfig);
+    }
   }
+
   await makeHappoAPIRequest(
     {
       path: `/api/async-reports/${afterSha}/finalize`,
       method: 'POST',
-      body,
+      body: {
+        project: happoConfig.project,
+        nonce,
+      },
     },
     happoConfig,
     { retryCount: 3 },
@@ -120,13 +126,37 @@ async function finalizeHappoReport(
   environment: EnvironmentResult,
   job: StartJobResult,
   logger: Logger,
+  skip?: Array<SkipItem>,
 ) {
   if (!allRequestIds.size) {
     logger.log(`[HAPPO] No snapshots were recorded. Ignoring.`);
     return;
   }
+
+  const requestIds = [...allRequestIds];
+
+  // Only borrow when this run finalizes the report. With a nonce, the report
+  // spans several parallel runs and is finalized by a separate `happo
+  // finalize` call — borrowing here would attach one extends-report per shard
+  // and duplicate the borrowed snapshots.
+  if (skip && skip.length > 0 && !environment.nonce) {
+    // Borrow the examples we skipped during the run from the baseline. Without
+    // a nonce the report is finalized by the POST below, so the extends-report
+    // has to be part of that same call.
+    const extendsRequestId = await createSkipExtendsRequest(
+      skip,
+      happoConfig,
+      environment,
+      logger,
+    );
+
+    if (extendsRequestId !== undefined) {
+      requestIds.push(extendsRequestId);
+    }
+  }
+
   const reportResult = await postAsyncReport(
-    [...allRequestIds],
+    requestIds,
     environment,
     happoConfig,
   );
@@ -242,7 +272,9 @@ export default async function runWithWrapper(
 
   // Write skipped examples to a temp file to avoid env var size limits.
   let skipFilePath: string | undefined;
+  let skip: Array<SkipItem> | undefined;
   if (skipJSON) {
+    skip = validateSkip(skipJSON);
     skipFilePath = path.join(os.tmpdir(), `happo-skipped-${process.pid}.json`);
     await fs.promises.writeFile(skipFilePath, skipJSON, 'utf8');
   }
@@ -280,7 +312,13 @@ export default async function runWithWrapper(
         async (code: number | null, signal: NodeJS.Signals | null) => {
           if (code === 0 || e2eIntegration.allowFailures) {
             try {
-              await finalizeHappoReport(happoConfig, environment, job, logger);
+              await finalizeHappoReport(
+                happoConfig,
+                environment,
+                job,
+                logger,
+                skip,
+              );
             } catch (e) {
               logger.error('Failed to finalize Happo report', e);
               return reject(e);

--- a/src/environment/index.ts
+++ b/src/environment/index.ts
@@ -732,7 +732,7 @@ export default async function resolveEnvironment(
     githubToken: cliArgs.githubToken,
     ci: !!env.CI,
     ciJobUrl: resolveCIJobUrl(env),
-    skip: cliArgs.skip,
+    skip: cliArgs.skip ?? cliArgs.skippedExamples,
     only: cliArgs.only,
   };
 

--- a/src/isomorphic/parseSkip.ts
+++ b/src/isomorphic/parseSkip.ts
@@ -21,12 +21,15 @@ function isSkipItem(item: unknown): item is SkipItem {
 /**
  * Parses and validates a JSON string, returning an array of SkipItems.
  * Throws a TypeError if the JSON is invalid or not an array of SkipItems.
+ *
+ * `flag` names the option in the error message, so that callers reached via
+ * the --skippedExamples alias don't report the wrong flag name.
  */
-export function validateSkip(json: string): Array<SkipItem> {
+export function validateSkip(json: string, flag = '--skip'): Array<SkipItem> {
   const parsed: unknown = JSON.parse(json);
   if (!Array.isArray(parsed) || !parsed.every(isSkipItem)) {
     throw new TypeError(
-      '--skip must be a JSON array of {component, variant?} or {storyFile} objects',
+      `${flag} must be a JSON array of {component, variant?} or {storyFile} objects`,
     );
   }
   return parsed;

--- a/src/network/createSkipExtendsRequest.ts
+++ b/src/network/createSkipExtendsRequest.ts
@@ -13,9 +13,11 @@ import findBaselineReport from './findBaselineReport.ts';
  * so the resulting report is complete on its own rather than relying on the
  * comparison to fill in the gaps.
  *
- * Returns undefined when there is nothing to borrow or no baseline report to
- * borrow from. In the latter case the skipped examples will show up as deleted
- * in the comparison, so we log about it.
+ * Returns undefined when there is nothing to borrow, or when no baseline could
+ * be resolved. findBaselineReport() reports both "there is no baseline" and
+ * "the lookup failed" as undefined (it logs the underlying error itself), so
+ * the message here has to cover both. Either way the skipped examples will show
+ * up as deleted in the comparison, which is worth saying out loud.
  */
 export default async function createSkipExtendsRequest(
   skip: Array<SkipItem>,
@@ -33,7 +35,7 @@ export default async function createSkipExtendsRequest(
 
   if (!baselineSha) {
     logger.log(
-      '[HAPPO] No baseline report found to borrow skipped examples from. They will show up as deleted in the comparison.',
+      '[HAPPO] Could not resolve a baseline report to borrow skipped examples from. They will show up as deleted in the comparison.',
     );
     return undefined;
   }

--- a/src/network/createSkipExtendsRequest.ts
+++ b/src/network/createSkipExtendsRequest.ts
@@ -1,0 +1,42 @@
+import type { ConfigWithDefaults } from '../config/index.ts';
+import type { EnvironmentResult } from '../environment/index.ts';
+import type { Logger, SkipItem } from '../isomorphic/types.ts';
+import createExtendsReportSnapRequest from './createExtendsReportSnapRequest.ts';
+import findBaselineReport from './findBaselineReport.ts';
+
+/**
+ * Resolves a skip list into an extends-report snap request that borrows the
+ * skipped examples from the nearest baseline report.
+ *
+ * This is the same mechanism the storybook/custom integrations use for
+ * `--skip`: the borrowed snapshots are the real snapshots from the baseline,
+ * so the resulting report is complete on its own rather than relying on the
+ * comparison to fill in the gaps.
+ *
+ * Returns undefined when there is nothing to borrow or no baseline report to
+ * borrow from. In the latter case the skipped examples will show up as deleted
+ * in the comparison, so we log about it.
+ */
+export default async function createSkipExtendsRequest(
+  skip: Array<SkipItem>,
+  config: ConfigWithDefaults,
+  environment: EnvironmentResult,
+  logger: Logger,
+): Promise<number | undefined> {
+  const componentItems = skip.filter((item) => 'component' in item);
+
+  if (componentItems.length === 0) {
+    return undefined;
+  }
+
+  const baselineSha = await findBaselineReport(environment, config, logger);
+
+  if (!baselineSha) {
+    logger.log(
+      '[HAPPO] No baseline report found to borrow skipped examples from. They will show up as deleted in the comparison.',
+    );
+    return undefined;
+  }
+
+  return await createExtendsReportSnapRequest(baselineSha, componentItems, config);
+}


### PR DESCRIPTION
Fixes a regression reported against v6: every entry passed to `happo finalize --skippedExamples` comes back as a **deletion**, so the deleted count on a run equals the length of the skip list.

## The bug

`finalizeAll` posted the skip list to `/api/async-reports/:sha/finalize` under the body key `skip`, but the API reads `skippedExamples` and has no fallback for `skip`. Unknown keys aren't rejected, so the client got a normal 200 and nothing appeared in any log — it failed completely silently.

How it got there:

- The `happo-e2e` v5 `finalizeAll` (ported in 73f7066) sent `skippedExamples`.
- d418bd9c26 ("Rename --skippedExamples to --skip throughout") renamed the CLI flag, env var, internal modules **and** the wire field. The wire field was collateral damage — nothing in that commit's stated intent covers changing the request body.
- #467 restored the flag name and help text, but only touched `src/cli/index.ts`, `parseOptions.ts` and the tests. It never touched `wrapper.ts`.

The tests didn't catch it because #467 renamed the *test titles* to `--skippedExamples` while leaving the assertions reading `body.skip` — they were pinning the broken field.

## The fix

Rather than restore the old wire field, this switches both e2e paths to the **extends-report** mechanism the Storybook/custom integrations already use for `--skip`. New shared helper `createSkipExtendsRequest.ts`: resolve a baseline via `find-baseline`, POST `/api/snap-requests/extends-report`, return the request id.

Why that mechanism, beyond consistency:

- The borrowed rows are the **real baseline snapshots** (url, target, dimensions), so the report is complete standalone. The placeholder mechanism only ever made sense inside a comparison; the report itself held 1×1 `url: 'skip'` entries.
- Baseline resolution goes through `find-baseline`, which walks `beforeSha` + `fallbackShas`, instead of depending on whichever report the comparison happens to diff against.
- With no baseline at all, placeholders landed as *added* 1×1 snapshots. Now we log and skip the borrow.

Sending both mechanisms wasn't an option — that produces two snapshots per skipped example (a real borrowed one and a placeholder) sharing the same `component+variant+target` key.

## Second bug fixed

`happo e2e --skip` (no nonce) had **no borrow at all**. It suppressed capture — both Cypress and Playwright check `isInSkipSet` — but nothing ever brought the baselines back, so those examples went straight to `deleted`. The extends-report id now goes into the same `postAsyncReport` call that finalizes the report.

Sharded runs are guarded on the nonce, so each shard doesn't attach its own extends-report and duplicate the borrowed snapshots — with a nonce, the separate `happo finalize` call does the borrowing.

## `--skip` and `--skippedExamples` are now true aliases

`--skippedExamples` was parsed globally but only the `finalize` command ever read it, because `environment.skip` came from `cliArgs.skip` alone. So `happo --skippedExamples '[...]'` on a Storybook run, or on `happo e2e`, was silently dropped — no skipping, no borrow, no error. Same failure mode as the main bug, one layer up.

Now that both the mechanism and the accepted shape are unified, the two names mean exactly the same thing, so they resolve to one value in `resolveEnvironment` and every command reads it. The imperative/declarative distinction is carried by the command (`finalize` can't skip anything by construction), not by the flag name.

Passing both is rejected rather than silently picking one, and error messages name whichever flag the user actually typed.

**Existing `--skippedExamples` callers need no changes.**

## Reviewer notes

- **`{component, variant, target}` payloads keep working.** The extra `target` key passes validation and is ignored server-side, so all targets get borrowed. That's correct here — Cypress and Playwright both skip per component+variant across *all* targets, so a skip is never target-specific to begin with. Repeated entries differing only by target collapse harmlessly, since the server filters the baseline snapshot list rather than expanding the input.
- **`storyFile` items are now rejected** for the finalize command and for `happo e2e`. They were inert there (`toSkipSet` ignores them, so they were never skipped at capture time either) and silently did nothing.
- **The API's `skippedExamples` handling is now unused by this client.** Older `happo-e2e` v5 clients still rely on it, so it can't be retired yet.
- **Not addressed here:** `findBaselineReport` logs an error on a plain 404, which is the normal "no baseline yet" case. Pre-existing, but it now surfaces on the e2e paths too. Small separate cleanup if wanted.

## Testing

`pnpm lint`, `pnpm build:types` and `pnpm test` all clean — 417 tests, 416 pass, 0 fail, 1 pre-existing skip.

New coverage for borrowing, the no-baseline fallback (using a realistic 404), the nonce guard, `storyFile` rejection, both alias directions, the both-flags conflict, and validation ordering in `runWithWrapper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
