### PR TITLE
Add navigatePerStory option to Storybook integration

### DIFF
--- a/src/config/RemoteBrowserTarget.ts
+++ b/src/config/RemoteBrowserTarget.ts
@@ -82,6 +82,14 @@ export interface ExecuteParams {
    * `waitForSelector` times out instead of silently warning.
    */
   failOnWaitForTimeout?: boolean;
+
+  /**
+   * When true, the worker renders each story by navigating to
+   * `iframe.html?id=<storyId>` instead of paging through stories in a
+   * single page load. Only takes effect for Storybook-style static
+   * packages. See `StorybookIntegration.navigatePerStory`.
+   */
+  storybookNavigatePerStory?: boolean;
 }
 
 function getPageSlices(pages: Array<Page>, chunks: number): Array<PageSlice> {
@@ -115,6 +123,7 @@ function buildChunkItem({
   assetsPackage,
   targetName,
   failOnWaitForTimeout,
+  storybookNavigatePerStory,
 }: {
   slice?: Array<unknown> | undefined;
   chunk?: Chunk | undefined;
@@ -128,6 +137,7 @@ function buildChunkItem({
   assetsPackage: string | undefined;
   targetName: string | undefined;
   failOnWaitForTimeout: boolean | undefined;
+  storybookNavigatePerStory: boolean | undefined;
 }): ChunkItem {
   const payloadString = JSON.stringify({
     viewport,
@@ -141,6 +151,7 @@ function buildChunkItem({
     pages: pageSlice,
     extendsSha: pageSlice ? pageSlice.extendsSha : undefined,
     failOnWaitForTimeout,
+    storybookNavigatePerStory,
   });
 
   const payloadHash = createHash(payloadString + (pageSlice ? Math.random() : ''));
@@ -245,6 +256,7 @@ export default class RemoteBrowserTarget {
       targetName,
       estimatedSnapsCount,
       failOnWaitForTimeout,
+      storybookNavigatePerStory,
     }: ExecuteParams,
     config: ConfigWithDefaults,
   ): Promise<Array<number>> {
@@ -258,6 +270,7 @@ export default class RemoteBrowserTarget {
       assetsPackage,
       targetName,
       failOnWaitForTimeout,
+      storybookNavigatePerStory,
     };
 
     // Build all chunk items up front

--- a/src/config/__tests__/RemoteBrowserTarget.test.ts
+++ b/src/config/__tests__/RemoteBrowserTarget.test.ts
@@ -483,6 +483,44 @@ describe('RemoteBrowserTarget', () => {
       });
     });
 
+    describe('with storybookNavigatePerStory', () => {
+      it('flows storybookNavigatePerStory: true into each item payload (bulk path)', async () => {
+        const target = new RemoteBrowserTarget('chrome', baseTarget);
+        await target.execute(
+          {
+            staticPackage: 'https://example.com/pkg.zip',
+            estimatedSnapsCount: 200,
+            targetName: 'chrome',
+            storybookNavigatePerStory: true,
+          },
+          config,
+        );
+        assert.strictEqual(bulkCalls.length, 1);
+        const items = bulkCalls[0]?.items ?? [];
+        assert.strictEqual(items.length, 2);
+        for (const item of items) {
+          const payload = JSON.parse(item.payloadString as string) as {
+            storybookNavigatePerStory?: unknown;
+          };
+          assert.strictEqual(payload.storybookNavigatePerStory, true);
+        }
+      });
+
+      it('omits storybookNavigatePerStory from the payload when not provided', async () => {
+        const target = new RemoteBrowserTarget('chrome', baseTarget);
+        await target.execute(
+          { staticPackage: 'https://example.com/pkg.zip', targetName: 'chrome' },
+          config,
+        );
+        assert.strictEqual(bulkCalls.length, 1);
+        assert.strictEqual(bulkCalls[0]?.items.length, 1);
+        const payload = JSON.parse(
+          bulkCalls[0]?.items[0]?.payloadString as string,
+        ) as Record<string, unknown>;
+        assert.strictEqual('storybookNavigatePerStory' in payload, false);
+      });
+    });
+
     describe('when bulk endpoint responds with invalid shape', () => {
       beforeEach(() => {
         simulateBulkInvalidShape = true;

--- a/src/config/__tests__/RemoteBrowserTarget.test.ts
+++ b/src/config/__tests__/RemoteBrowserTarget.test.ts
@@ -506,6 +506,24 @@ describe('RemoteBrowserTarget', () => {
         }
       });
 
+      it('flows storybookNavigatePerStory: false into the item payload', async () => {
+        const target = new RemoteBrowserTarget('chrome', baseTarget);
+        await target.execute(
+          {
+            staticPackage: 'https://example.com/pkg.zip',
+            targetName: 'chrome',
+            storybookNavigatePerStory: false,
+          },
+          config,
+        );
+        assert.strictEqual(bulkCalls.length, 1);
+        assert.strictEqual(bulkCalls[0]?.items.length, 1);
+        const payload = JSON.parse(
+          bulkCalls[0]?.items[0]?.payloadString as string,
+        ) as { storybookNavigatePerStory?: unknown };
+        assert.strictEqual(payload.storybookNavigatePerStory, false);
+      });
+
       it('omits storybookNavigatePerStory from the payload when not provided', async () => {
         const target = new RemoteBrowserTarget('chrome', baseTarget);
         await target.execute(

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,6 +21,24 @@ export interface StorybookIntegration {
    * sure that files are built to the outputDir.
    */
   usePrebuiltPackage?: boolean;
+
+  /**
+   * When `true`, each story is rendered by navigating directly to
+   * `iframe.html?id=<storyId>` instead of loading `iframe.html` once and
+   * paging through stories client-side.
+   *
+   * This is slower (one navigation per story) but gives every story a fresh
+   * page load, which can help with Storybooks where state leaks between
+   * stories (e.g. through global CSS, singletons, or other side effects that
+   * the default in-page navigation doesn't reset).
+   *
+   * Requires an `index.json` or `stories.json` file in the built Storybook
+   * package. If missing, Happo falls back to the default navigation
+   * strategy.
+   *
+   * @default false
+   */
+  navigatePerStory?: boolean;
 }
 
 interface BaseE2EIntegration {

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -233,7 +233,7 @@ export default async function prepareSnapRequests(
 
       if (
         config.integration.type === 'storybook' &&
-        config.integration.navigatePerStory
+        config.integration.navigatePerStory === true
       ) {
         targetParams.storybookNavigatePerStory = true;
       }

--- a/src/network/prepareSnapRequests.ts
+++ b/src/network/prepareSnapRequests.ts
@@ -231,6 +231,13 @@ export default async function prepareSnapRequests(
         targetParams.pages = config.integration.pages;
       }
 
+      if (
+        config.integration.type === 'storybook' &&
+        config.integration.navigatePerStory
+      ) {
+        targetParams.storybookNavigatePerStory = true;
+      }
+
       const ids = await target.execute(targetParams, config);
       logger.start(`  - ${logTag(config.project)}${name}`, { startTime });
       logger.success();


### PR DESCRIPTION
## Summary

Adds a new `navigatePerStory` option to the Storybook integration config:

```ts
export default defineConfig({
  integration: {
    type: 'storybook',
    navigatePerStory: true,
  },
  // ...
});
```

When enabled, each story is rendered by navigating directly to `iframe.html?id=<storyId>` instead of loading `iframe.html` once and paging through stories client-side. This is slower (one navigation per story) but gives every story a fresh page load, which can help with Storybooks where state leaks between stories — e.g. through global CSS, singletons, or other side effects that the default in-page navigation doesn't reset.

Requires an `index.json` or `stories.json` file in the built Storybook package (present in normal Storybook builds). If missing, Happo falls back to the default navigation strategy.

## Changes

- `src/config/index.ts` — new `navigatePerStory?: boolean` field on `StorybookIntegration` (default `false`).
- `src/config/RemoteBrowserTarget.ts` — threads the option through `execute()` into the snap-request payload, following the same pattern as the existing `failOnWaitForTimeout` option.
- `src/network/prepareSnapRequests.ts` — passes `navigatePerStory` from the Storybook integration config into the per-target execute params.
- `src/config/__tests__/RemoteBrowserTarget.test.ts` — tests covering that the flag is included in the payload when set and omitted when not.

## Testing

- `pnpm build:types`
- `pnpm lint`
- `pnpm test` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)