### PR TITLE
Add support for configuring animated (APNG) snapshots via `animate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Each target supports advanced options like:
 - Maximum dimensions
 - Color scheme preferences
 - Settings for silencing animations
+- Animated (APNG) snapshot capture via `animate` (experimental, not supported on `ios-safari`/`ipad-safari`)
 
 ## 🤝 Contributing
 

--- a/src/config/__tests__/loadConfig.test.ts
+++ b/src/config/__tests__/loadConfig.test.ts
@@ -684,6 +684,153 @@ describe('loadConfigFile', () => {
     assert.strictEqual(config.targets['chrome']?.allowPointerEvents, false);
   });
 
+  describe('animate validation', () => {
+    it('throws an error when animate: true is set on an ios-safari target', async () => {
+      tmpfs.mock({
+        'happo.config.ts': `
+          export default {
+            apiKey: 'test-api-key',
+            apiSecret: 'test-api-secret',
+            targets: {
+              mobile: {
+                type: 'ios-safari',
+                animate: true,
+              },
+            },
+          };
+        `,
+      });
+
+      await assert.rejects(
+        loadConfigFile(findConfigFile(), { link: undefined, ci: false }),
+        /Invalid `animate` in config file \S+: animated snapshots are not supported on "ios-safari" targets/,
+      );
+    });
+
+    it('throws an error when animate: "auto" is set on an ipad-safari target', async () => {
+      tmpfs.mock({
+        'happo.config.ts': `
+          export default {
+            apiKey: 'test-api-key',
+            apiSecret: 'test-api-secret',
+            targets: {
+              tablet: {
+                type: 'ipad-safari',
+                animate: 'auto',
+              },
+            },
+          };
+        `,
+      });
+
+      await assert.rejects(
+        loadConfigFile(findConfigFile(), { link: undefined, ci: false }),
+        /Invalid `animate` in config file \S+: animated snapshots are not supported on "ipad-safari" targets/,
+      );
+    });
+
+    it('throws an error when a trigger is set on an ios-safari target, even without an explicit mode', async () => {
+      tmpfs.mock({
+        'happo.config.ts': `
+          export default {
+            apiKey: 'test-api-key',
+            apiSecret: 'test-api-secret',
+            targets: {
+              mobile: {
+                type: 'ios-safari',
+                animate: {
+                  trigger: { selector: '.toast', action: 'addClass', value: 'is-open' },
+                },
+              },
+            },
+          };
+        `,
+      });
+
+      await assert.rejects(
+        loadConfigFile(findConfigFile(), { link: undefined, ci: false }),
+        /Invalid `animate` in config file \S+: animated snapshots are not supported on "ios-safari" targets/,
+      );
+    });
+
+    it('allows animate: false on an ios-safari target', async () => {
+      tmpfs.mock({
+        'happo.config.ts': `
+          export default {
+            apiKey: 'test-api-key',
+            apiSecret: 'test-api-secret',
+            targets: {
+              mobile: {
+                type: 'ios-safari',
+                animate: false,
+              },
+            },
+          };
+        `,
+      });
+
+      const config = await loadConfigFile(findConfigFile(), {
+        link: undefined,
+        ci: false,
+      });
+
+      assert.strictEqual(config.targets['mobile']?.animate, false);
+    });
+
+    it('allows animate: { mode: "off" } on an ipad-safari target', async () => {
+      tmpfs.mock({
+        'happo.config.ts': `
+          export default {
+            apiKey: 'test-api-key',
+            apiSecret: 'test-api-secret',
+            targets: {
+              tablet: {
+                type: 'ipad-safari',
+                animate: { mode: 'off' },
+              },
+            },
+          };
+        `,
+      });
+
+      const config = await loadConfigFile(findConfigFile(), {
+        link: undefined,
+        ci: false,
+      });
+
+      assert.deepStrictEqual(config.targets['tablet']?.animate, { mode: 'off' });
+    });
+
+    it('allows animate on a desktop target and passes it through unchanged', async () => {
+      tmpfs.mock({
+        'happo.config.ts': `
+          export default {
+            apiKey: 'test-api-key',
+            apiSecret: 'test-api-secret',
+            targets: {
+              chrome: {
+                type: 'chrome',
+                viewport: '1024x768',
+                animate: { mode: 'auto', fps: 15, maxFrames: 60 },
+              },
+            },
+          };
+        `,
+      });
+
+      const config = await loadConfigFile(findConfigFile(), {
+        link: undefined,
+        ci: false,
+      });
+
+      assert.deepStrictEqual(config.targets['chrome']?.animate, {
+        mode: 'auto',
+        fps: 15,
+        maxFrames: 60,
+      });
+    });
+  });
+
   describe('deepCompare validation', () => {
     it('accepts valid deepCompare settings', async () => {
       tmpfs.mock({

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,12 @@
+import type { AnimateConfig } from '../isomorphic/types.ts';
+
+export type {
+  AnimateConfig,
+  AnimateMode,
+  AnimateOptions,
+  AnimateTrigger,
+} from '../isomorphic/types.ts';
+
 export interface StorybookIntegration {
   type: 'storybook';
 
@@ -129,6 +138,17 @@ export interface Page {
    * taken anyway.
    */
   waitForSelector?: string;
+
+  /**
+   * Capture an animated (APNG) snapshot of this page by stepping its
+   * animations through a series of explicit times and encoding the frames
+   * into a single file. Merges over the target's `animate` setting, field by
+   * field. See the `animate` option on targets for details.
+   *
+   * @experimental This option and its shape are still evolving and may
+   * change in a future release.
+   */
+  animate?: AnimateConfig;
 }
 
 interface PagesIntegration {
@@ -387,6 +407,32 @@ interface BaseTarget {
    * frame.
    */
   freezeAnimations?: 'last-frame' | 'first-frame';
+
+  /**
+   * Capture animated (APNG) snapshots by stepping a page's animations
+   * through a series of explicit times and encoding the frames into a
+   * single file. The result is a valid plain PNG as well as an APNG: frame 0
+   * is the default image, so anything that doesn't understand animated PNGs
+   * sees the first frame and behaves exactly as it does for a normal
+   * snapshot.
+   *
+   * Shorthands: `animate: true` means `{ mode: 'always' }`, `animate: false`
+   * means `{ mode: 'off' }`, and `animate: 'auto'` means `{ mode: 'auto' }`.
+   *
+   * `'auto'` captures only the snapshots that have an animation Happo can
+   * drive, and leaves everything else as a still, so it's safe to turn on
+   * for a whole target without paying for every static story.
+   *
+   * Per-story options (set via `parameters.happo.animate` in Storybook, or
+   * per-page for the `pages` integration) merge over the target's, field by
+   * field.
+   *
+   * Not supported on `ios-safari` or `ipad-safari` targets.
+   *
+   * @experimental This option and its shape are still evolving and may
+   * change in a future release.
+   */
+  animate?: AnimateConfig;
 }
 
 interface MobileSafariTarget extends BaseTarget {

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -109,6 +109,30 @@ async function getFallbackApiToken(
   return undefined;
 }
 
+/**
+ * Determines whether a target's `animate` setting would actually trigger
+ * animated snapshot capture, accounting for the shorthands (`true`,
+ * `false`, `'auto'`) as well as a trigger implicitly turning capture on.
+ */
+function isAnimateEnabled(animate: TargetWithDefaults['animate']): boolean {
+  if (animate === undefined || animate === false) {
+    return false;
+  }
+
+  if (animate === true || animate === 'auto') {
+    return true;
+  }
+
+  if (typeof animate === 'object' && animate !== null) {
+    if (animate.trigger) {
+      return true;
+    }
+    return animate.mode !== undefined && animate.mode !== 'off';
+  }
+
+  return false;
+}
+
 function validateDeepCompareSettings(
   deepCompare: DeepCompareSettings,
   configFilePath: string,
@@ -299,6 +323,15 @@ export async function loadConfigFile(
     target.freezeAnimations = target.freezeAnimations || 'last-frame';
     target.prefersReducedMotion = target.prefersReducedMotion ?? true;
     target.allowPointerEvents = target.allowPointerEvents ?? true;
+
+    if (
+      (target.type === 'ios-safari' || target.type === 'ipad-safari') &&
+      isAnimateEnabled(target.animate)
+    ) {
+      throw new TypeError(
+        `Invalid \`animate\` in config file ${configFilePath}: animated snapshots are not supported on "${target.type}" targets. Remove \`animate\` from this target, or capture it in a Playwright-driven browser (chrome, firefox, edge, or safari) instead.`,
+      );
+    }
   }
 
   // Validate deepCompare settings if present

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -81,6 +81,7 @@ const happoStatic = {
           variant: example.variant,
           targets: example.targets,
           waitForContent: example.waitForContent,
+          animate: example.animate,
         };
       },
     };

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -65,7 +65,131 @@ export interface NextExampleResult {
   skipped?: boolean;
   waitForContent?: string | undefined;
   render?: () => Promise<void> | void;
+  animate?: AnimateConfig | undefined;
 }
+
+export type AnimateMode = 'off' | 'auto' | 'always';
+
+export interface AnimateTrigger {
+  /**
+   * CSS selector for the element to provoke. Matched through shadow roots.
+   */
+  selector: string;
+
+  /**
+   * The action to perform on the matched element in order to provoke the
+   * animation or transition.
+   */
+  action:
+    | 'addClass'
+    | 'removeClass'
+    | 'setAttribute'
+    | 'removeAttribute'
+    | 'click'
+    | 'focus'
+    | 'hover';
+
+  /**
+   * The value associated with the action:
+   * - `addClass` / `removeClass`: the class name
+   * - `setAttribute`: an attribute name/value pair, or a bare string, which
+   *   sets the attribute to `""`
+   * - `removeAttribute`: the attribute name
+   * - `click` / `focus` / `hover`: not used
+   */
+  value?: string | { name: string; value: string };
+}
+
+export interface AnimateOptions {
+  /**
+   * - `'off'` (default): capture a still, as usual.
+   * - `'auto'`: capture an animated PNG only when there is something Happo
+   *   can drive (a CSS animation/transition, `element.animate()`, SMIL, or a
+   *   `requestAnimationFrame` loop when `clock: 'virtual'` is armed).
+   *   Anything else is captured as a still.
+   * - `'always'`: capture an animated PNG even when nothing on the page
+   *   reports a duration of its own (e.g. a `requestAnimationFrame` loop).
+   */
+  mode?: AnimateMode;
+
+  /**
+   * Capture window, in milliseconds, or `'auto'` to derive it from the
+   * animations found on the page.
+   *
+   * @default 'auto'
+   */
+  duration?: number | 'auto';
+
+  /**
+   * Ceiling for a derived `duration`. Also the window used by
+   * `mode: 'always'`, since nothing reports a duration of its own in that
+   * case.
+   *
+   * @default 4000
+   */
+  maxDuration?: number;
+
+  /**
+   * Sampling rate, in frames per second. E.g. 500ms at `fps: 6` is 3 frames,
+   * not 6.
+   *
+   * @default 10
+   */
+  fps?: number;
+
+  /**
+   * Hard cap on the number of frames captured. Wins over `fps` × `duration`.
+   *
+   * @default 24
+   */
+  maxFrames?: number;
+
+  /**
+   * Set to `'virtual'` to replace the page's clock so that
+   * `requestAnimationFrame` animations can be stepped. Must be armed on the
+   * target for a story to be able to use it, since it has to be installed
+   * before the page loads.
+   *
+   * @default 'off'
+   */
+  clock?: 'off' | 'virtual';
+
+  /**
+   * What to do to the page in order to start the animation. Needed for CSS
+   * transitions and other animations that don't exist until something
+   * provokes them.
+   *
+   * Setting a trigger turns capturing on by itself, but it will not override
+   * an explicitly set `mode`, including `mode: 'off'`.
+   */
+  trigger?: AnimateTrigger | null;
+
+  /**
+   * APNG `num_plays`. `0` loops forever.
+   *
+   * @default 0
+   */
+  loop?: number;
+
+  /**
+   * Size budget, in bytes. Overshooting drops frames rather than the
+   * snapshot.
+   *
+   * @default 4_000_000
+   */
+  maxBytes?: number;
+}
+
+/**
+ * Configures animated (APNG) snapshot capture.
+ *
+ * Shorthands: `true` means `{ mode: 'always' }`, `false` means
+ * `{ mode: 'off' }`, and `'auto'` means `{ mode: 'auto' }`.
+ *
+ * @experimental This option and its shape are still evolving and may change
+ * in a future release.
+ */
+export type AnimateConfig = AnimateOptions | boolean | 'auto';
 
 export type WindowHappo = {
   init?: (config: InitConfig) => Promise<void> | void;

--- a/src/storybook/browser/register.ts
+++ b/src/storybook/browser/register.ts
@@ -2,6 +2,7 @@ import type { Channel } from 'storybook/internal/channels';
 import type { StoryStore } from 'storybook/internal/preview-api';
 
 import type {
+  AnimateConfig,
   InitConfig,
   NextExampleResult,
   WindowHappo,
@@ -58,6 +59,7 @@ interface Example {
   afterScreenshot: HookFunction;
   targets: Array<string>;
   theme?: string;
+  animate: AnimateConfig | undefined;
 }
 
 let renderTimeoutMs = 2000;
@@ -162,6 +164,7 @@ async function getExamples(): Promise<Array<Example>> {
       let afterScreenshot;
       let targets;
       let themes;
+      let animate;
       if (typeof parameters.happo === 'object' && parameters.happo !== null) {
         delay = parameters.happo.delay || defaultDelay;
         waitForContent = parameters.happo.waitForContent;
@@ -170,6 +173,7 @@ async function getExamples(): Promise<Array<Example>> {
         afterScreenshot = parameters.happo.afterScreenshot;
         targets = parameters.happo.targets;
         themes = parameters.happo.themes;
+        animate = parameters.happo.animate;
       }
       return {
         component: kind,
@@ -182,6 +186,7 @@ async function getExamples(): Promise<Array<Example>> {
         afterScreenshot,
         targets,
         themes,
+        animate,
       };
     })
     .filter(isDefined)
@@ -387,6 +392,7 @@ globalThis.happo.nextExample = async (): Promise<NextExampleResult | undefined> 
     waitFor,
     beforeScreenshot,
     theme,
+    animate,
   } = example;
 
   let pausedAtStep;
@@ -469,7 +475,7 @@ globalThis.happo.nextExample = async (): Promise<NextExampleResult | undefined> 
       highlightsRootElement.dataset.happoIgnore = 'true';
     }
 
-    return { component, variant, waitForContent };
+    return { component, variant, waitForContent, animate };
   } catch (e) {
     console.warn(e);
     return { component, variant };


### PR DESCRIPTION
## Summary

Adds support for the new `animate` configuration option, which lets Happo step through a page's animations and encode the captured frames into a single animated PNG (APNG) snapshot, instead of freezing on a single frame.

> ⚠️ **Experimental**: this option (and its shape) is still evolving and may change in a future release.

## What's included

- **Target-level `animate`** (`BaseTarget`), supporting the shorthands `true` / `false` / `'auto'`, plus a full options object: `mode`, `duration`, `maxDuration`, `fps`, `maxFrames`, `clock`, `trigger`, `loop`, `maxBytes`. This flows straight through to the snap-request payload via the existing `otherOptions` passthrough in `RemoteBrowserTarget` — no changes needed there.
- **Per-page `animate` override** for the `pages` integration (`Page`), which merges over the target's setting.
- **Per-story `animate` override** for Storybook, read from `parameters.happo.animate` and threaded through `nextExample()` alongside the existing `waitForContent`/`targets` fields.
- Same per-example passthrough for the `custom` integration.
- **Config-load validation** that rejects `animate` on `ios-safari` and `ipad-safari` targets (animated capture isn't supported there), failing fast with a clear error message instead of silently producing a still.

## Testing

- Added test coverage in `loadConfig.test.ts` for the `ios-safari`/`ipad-safari` rejection (including the case where only a `trigger` is set, with no explicit `mode`) and for successful passthrough on desktop targets.
- `pnpm build:types`, `pnpm lint`, and `pnpm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)