### PR TITLE
Support prefersReducedMotion override on animate

### DIFF
--- a/src/config/__tests__/loadConfig.test.ts
+++ b/src/config/__tests__/loadConfig.test.ts
@@ -829,6 +829,34 @@ describe('loadConfigFile', () => {
         maxFrames: 60,
       });
     });
+
+    it('allows a nested prefersReducedMotion override and passes it through unchanged', async () => {
+      tmpfs.mock({
+        'happo.config.ts': `
+          export default {
+            apiKey: 'test-api-key',
+            apiSecret: 'test-api-secret',
+            targets: {
+              chrome: {
+                type: 'chrome',
+                viewport: '1024x768',
+                animate: { mode: 'auto', prefersReducedMotion: false },
+              },
+            },
+          };
+        `,
+      });
+
+      const config = await loadConfigFile(findConfigFile(), {
+        link: undefined,
+        ci: false,
+      });
+
+      assert.deepStrictEqual(config.targets['chrome']?.animate, {
+        mode: 'auto',
+        prefersReducedMotion: false,
+      });
+    });
   });
 
   describe('deepCompare validation', () => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -445,6 +445,11 @@ interface BaseTarget {
    * per-page for the `pages` integration) merge over the target's, field by
    * field.
    *
+   * Set a nested `prefersReducedMotion` to override the target's
+   * `prefersReducedMotion` for just this capture, in either direction (e.g.
+   * `animate: { mode: 'auto', prefersReducedMotion: false }` to let an
+   * animation run even though the target prefers reduced motion).
+   *
    * Not supported on `ios-safari` or `ipad-safari` targets.
    *
    * @experimental This option and its shape are still evolving and may
@@ -468,6 +473,9 @@ interface DesktopTarget extends BaseTarget {
   /**
    * By default, Happo makes the browser prefer reduced motion when rendering
    * the UI. Set `prefersReducedMotion: false` to disable this behavior.
+   *
+   * To override this for a single `animate` capture instead of the whole
+   * target, set `prefersReducedMotion` inside that snap's `animate` options.
    */
   prefersReducedMotion?: boolean;
 

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -178,6 +178,25 @@ export interface AnimateOptions {
    * @default 4_000_000
    */
   maxBytes?: number;
+
+  /**
+   * Overrides the target's `prefersReducedMotion` setting for just this
+   * capture, in either direction. `null` (the default) inherits the
+   * target's setting.
+   *
+   * A page that honours `prefers-reduced-motion` typically turns its own
+   * animation off, which leaves `animate` with nothing to step through and
+   * it quietly falls back to a still. Since targets prefer reduced motion
+   * by default, set `prefersReducedMotion: false` here to switch it off for
+   * this capture so the animation actually runs.
+   *
+   * Reduced motion sometimes only trims an animation rather than removing
+   * it outright, and that trimmed version can be worth capturing on its
+   * own — this is opt-in rather than automatic for that reason.
+   *
+   * @default null
+   */
+  prefersReducedMotion?: boolean | null;
 }
 
 /**


### PR DESCRIPTION
## Why

happo-snap now supports an opt-in `prefersReducedMotion` override nested inside `animate` options (happo/happo-snap#1321).

A page that honours `prefers-reduced-motion` typically turns its own animation off, which leaves `animate` with nothing to step through and it quietly falls back to a still — surprising the first time someone turns `animate` on, since targets prefer reduced motion by default.

## What changed

Since this field is forwarded to happo.io unchanged (like every other `AnimateOptions` field — this client passes `animate` through opaquely), only the type and its docs needed updating:

- `AnimateOptions.prefersReducedMotion?: boolean | null` in `src/isomorphic/types.ts`. `null` (default) inherits the target's `prefersReducedMotion` setting; `true`/`false` overrides it for just that capture, in either direction:

  ```ts
  targets: {
    'chrome-desktop': {
      type: 'chrome',
      animate: { mode: 'auto', prefersReducedMotion: false },
    },
  }
  ```

- Cross-referenced the new nested option from the target-level `animate` doc and the top-level `prefersReducedMotion` doc in `src/config/index.ts`.
- Added a passthrough test in `loadConfig.test.ts`.

## Testing

- `pnpm build:types` — clean
- `pnpm lint` — clean
- `pnpm test loadConfig` — 465 passed, including the new test

🤖 Generated with [Claude Code](https://claude.com/claude-code)