### PR TITLE
Call happoAnimate.beforeRender and type animate hooks and drivers

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,7 +7,13 @@ export type {
   AnimateMode,
   AnimateOptions,
   AnimateSampling,
+  AnimateTrace,
   AnimateTrigger,
+  AnimationDriver,
+  AnimationDriverHandle,
+  StoryAnimateConfig,
+  StoryAnimateOptions,
+  WindowHappoAnimate,
 } from '../isomorphic/types.ts';
 
 export interface StorybookIntegration {

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -65,7 +65,7 @@ export interface NextExampleResult {
   skipped?: boolean;
   waitForContent?: string | undefined;
   render?: () => Promise<void> | void;
-  animate?: AnimateConfig | undefined;
+  animate?: StoryAnimateConfig | undefined;
 }
 
 export type AnimateMode = 'off' | 'auto' | 'always';
@@ -161,14 +161,8 @@ export interface AnimateOptions {
    *
    * Setting a trigger turns capturing on by itself, but it will not override
    * an explicitly set `mode`, including `mode: 'off'`.
-   *
-   * On a story, this can also be a function, which is run on the page. A
-   * function trigger doesn't turn capturing on by itself -- set `mode`.
    */
-  trigger?:
-    | AnimateTrigger
-    | ((context: { rootElement: HTMLElement }) => void | Promise<void>)
-    | null;
+  trigger?: AnimateTrigger | null;
 
   /**
    * APNG `num_plays`. `0` loops forever.
@@ -271,12 +265,33 @@ export interface AnimateOptions {
    * @default null
    */
   drivers?: Array<string> | null;
+}
+
+/**
+ * `animate` as a Storybook story sets it, in `parameters.happo.animate`.
+ *
+ * On top of everything a target or page can set, a story can bring hooks.
+ * They run on the page, next to the story: target and page configuration is
+ * serialized before it reaches the worker, and functions don't survive that,
+ * so only a story can have them.
+ */
+export interface StoryAnimateOptions extends Omit<AnimateOptions, 'trigger'> {
+  /**
+   * What to do to the page in order to start the animation -- the same as a
+   * target's `trigger`, or a function that is run on the page. A story's
+   * trigger replaces the target's. A function trigger doesn't turn capturing
+   * on by itself; set `mode`.
+   */
+  trigger?:
+    | AnimateTrigger
+    | ((context: { rootElement: HTMLElement }) => void | Promise<void>)
+    | null;
 
   /**
-   * Story-level only. Runs right before the story renders, inside its
-   * motion environment -- for undoing whatever a harness does to keep
-   * stills still (e.g. a shim that makes `element.animate()` zero
-   * duration). Return a function to undo it after the screenshot.
+   * Runs right before the story renders, inside its motion environment --
+   * for undoing whatever a harness does to keep stills still (e.g. a shim
+   * that makes `element.animate()` zero duration). Return a function to undo
+   * it after the screenshot.
    *
    * A hook that throws is reported like a failed `verify`.
    */
@@ -288,11 +303,17 @@ export interface AnimateOptions {
     | Promise<void | (() => void | Promise<void>)>;
 
   /**
-   * Story-level only. Runs after the capture with a trace of what was found.
-   * Throw to fail the capture, the way `onExpectationFailure` says.
+   * Runs after the capture with a trace of what was found. Throw to fail the
+   * capture, the way `onExpectationFailure` says.
    */
   verify?: (trace: AnimateTrace) => void | Promise<void>;
 }
+
+/**
+ * `animate` as a story sets it: see `StoryAnimateOptions`. Shorthands as for
+ * `AnimateConfig`.
+ */
+export type StoryAnimateConfig = StoryAnimateOptions | boolean | 'auto';
 
 /**
  * What an animated capture found, as handed to a story's `verify` hook.
@@ -350,7 +371,8 @@ export interface AnimationDriver {
   /** Used in `drivers` and `expect.drivers`. */
   name: string;
   /**
-   * Returns a handle for each animation under `root`. Called whenever
+   * Returns a handle for each animation under `root` -- only those, since
+   * `root` is how a capture is limited to part of the page. Called whenever
    * Happo looks for animations: once, or every frame of a `discovery`
    * window.
    */
@@ -361,7 +383,7 @@ export interface AnimationDriver {
  * `window.happoAnimate`, set up by the Happo worker during a Happo run.
  */
 export interface WindowHappoAnimate {
-  beforeRender: (animate: AnimateConfig | undefined) => Promise<boolean>;
+  beforeRender: (animate: StoryAnimateConfig | undefined) => Promise<boolean>;
   registerDriver: (driver: AnimationDriver) => void;
 }
 

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -65,7 +65,12 @@ export interface NextExampleResult {
   skipped?: boolean;
   waitForContent?: string | undefined;
   render?: () => Promise<void> | void;
-  animate?: StoryAnimateConfig | undefined;
+  /**
+   * Serializable, like the rest of the result: it goes to the worker. A
+   * Storybook story's hooks reach the page separately, through
+   * `happoAnimate.beforeRender()` -- see `StoryAnimateOptions`.
+   */
+  animate?: AnimateConfig | undefined;
 }
 
 export type AnimateMode = 'off' | 'auto' | 'always';

--- a/src/isomorphic/types.ts
+++ b/src/isomorphic/types.ts
@@ -161,8 +161,14 @@ export interface AnimateOptions {
    *
    * Setting a trigger turns capturing on by itself, but it will not override
    * an explicitly set `mode`, including `mode: 'off'`.
+   *
+   * On a story, this can also be a function, which is run on the page. A
+   * function trigger doesn't turn capturing on by itself -- set `mode`.
    */
-  trigger?: AnimateTrigger | null;
+  trigger?:
+    | AnimateTrigger
+    | ((context: { rootElement: HTMLElement }) => void | Promise<void>)
+    | null;
 
   /**
    * APNG `num_plays`. `0` loops forever.
@@ -257,6 +263,106 @@ export interface AnimateOptions {
    * @default 'image'
    */
   onExpectationFailure?: 'image' | 'fail' | 'warn';
+
+  /**
+   * Which drivers registered with `registerAnimationDriver` to use. `null`
+   * (the default) uses all of them.
+   *
+   * @default null
+   */
+  drivers?: Array<string> | null;
+
+  /**
+   * Story-level only. Runs right before the story renders, inside its
+   * motion environment -- for undoing whatever a harness does to keep
+   * stills still (e.g. a shim that makes `element.animate()` zero
+   * duration). Return a function to undo it after the screenshot.
+   *
+   * A hook that throws is reported like a failed `verify`.
+   */
+  setup?: (context: {
+    rootElement: HTMLElement;
+  }) =>
+    | void
+    | (() => void | Promise<void>)
+    | Promise<void | (() => void | Promise<void>)>;
+
+  /**
+   * Story-level only. Runs after the capture with a trace of what was found.
+   * Throw to fail the capture, the way `onExpectationFailure` says.
+   */
+  verify?: (trace: AnimateTrace) => void | Promise<void>;
+}
+
+/**
+ * What an animated capture found, as handed to a story's `verify` hook.
+ */
+export interface AnimateTrace {
+  /** Animations found, including the ones drivers found. */
+  animationCount: number;
+  /** SVG roots with SMIL animations. */
+  svgCount: number;
+  /** Animations found per driver, e.g. `{ lottie: 2 }`. */
+  driverCounts: Record<string, number>;
+  /** Up to 20 of the animations found. */
+  animations: Array<{
+    kind: string;
+    name: string | null;
+    target: string | null;
+    startMs: number;
+    endMs: number;
+  }>;
+  /** The capture window, in milliseconds. */
+  durationMs: number;
+  /** The times sampled, in milliseconds. */
+  frameTimes: Array<number>;
+  /** Distinct frames in the encoded APNG. */
+  frameCount: number;
+}
+
+/**
+ * One animation a driver can seek. See `registerAnimationDriver`.
+ */
+export interface AnimationDriverHandle {
+  /**
+   * What the handle drives, e.g. a Lottie instance. Discovery can run once
+   * per frame, and a handle with a `target` seen before is the same
+   * animation found again.
+   */
+  target?: object;
+  /** How long it runs, in milliseconds. */
+  durationMs: number;
+  /** Renders the animation at `timeMs`. Return a promise if that isn't immediate. */
+  seek: (timeMs: number) => void | Promise<void>;
+  /** Stops it moving on its own. */
+  pause?: () => void;
+  /** Hands it back after the capture. */
+  release?: () => void;
+  /** `true` for a loop, which is sampled half-open. */
+  repeats?: boolean;
+  /** Shown in the trace. */
+  name?: string;
+  /** Shown in the trace. */
+  element?: Element;
+}
+
+export interface AnimationDriver {
+  /** Used in `drivers` and `expect.drivers`. */
+  name: string;
+  /**
+   * Returns a handle for each animation under `root`. Called whenever
+   * Happo looks for animations: once, or every frame of a `discovery`
+   * window.
+   */
+  discover: (root: Element) => Array<AnimationDriverHandle>;
+}
+
+/**
+ * `window.happoAnimate`, set up by the Happo worker during a Happo run.
+ */
+export interface WindowHappoAnimate {
+  beforeRender: (animate: AnimateConfig | undefined) => Promise<boolean>;
+  registerDriver: (driver: AnimationDriver) => void;
 }
 
 export interface AnimateDiscovery {
@@ -291,6 +397,12 @@ export interface AnimateExpectations {
 
   /** `true` requires the `trigger` to have matched an element. */
   triggered?: boolean;
+
+  /**
+   * At least this many animations found by each named driver, e.g.
+   * `{ lottie: 1 }` so that a Lottie that never mounted fails the capture.
+   */
+  drivers?: Record<string, number>;
 }
 
 /**

--- a/src/storybook/browser/register.ts
+++ b/src/storybook/browser/register.ts
@@ -3,9 +3,11 @@ import type { StoryStore } from 'storybook/internal/preview-api';
 
 import type {
   AnimateConfig,
+  AnimationDriver,
   InitConfig,
   NextExampleResult,
   WindowHappo,
+  WindowHappoAnimate,
 } from '../../isomorphic/types.ts';
 import type { OnlyItems, SkipItems } from '../isomorphic/types.ts';
 import { SB_ROOT_ELEMENT_SELECTOR } from './constants.ts';
@@ -33,6 +35,8 @@ declare global {
       }
     | undefined;
   var __STORYBOOK_ADDONS_CHANNEL__: Channel | undefined;
+  // Set up by the Happo worker, and only during a Happo run.
+  var happoAnimate: WindowHappoAnimate | undefined;
 }
 
 const time = globalThis.happoTime || {
@@ -417,6 +421,14 @@ globalThis.happo.nextExample = async (): Promise<NextExampleResult | undefined> 
       }
     }
 
+    // A story that animates has to render in its motion environment: its
+    // reduced-motion override, its `setup` hook, and the worker's capture
+    // styles all have to be in place before it mounts, or it has already
+    // decided how to animate. The worker decides whether the story needs one.
+    if (globalThis.happoAnimate) {
+      await globalThis.happoAnimate.beforeRender(animate);
+    }
+
     const renderResult = await renderStory(
       {
         kind: component,
@@ -533,6 +545,27 @@ export function setThemeSwitcher(
 
 export function setShouldWaitForCompletedEvent(swfce: boolean): void {
   shouldWaitForCompletedEvent = swfce;
+}
+
+/**
+ * Teaches Happo to capture an animation it can't see on its own -- anything
+ * that runs its own frame loop, like Lottie -- in animated snapshots. Does
+ * nothing outside a Happo run, so it's safe to call from a Storybook preview.
+ *
+ * @example
+ * registerAnimationDriver({
+ *   name: 'lottie',
+ *   discover: () =>
+ *     lottie.getRegisteredAnimations().map((animation) => ({
+ *       target: animation,
+ *       durationMs: (animation.totalFrames / animation.frameRate) * 1000,
+ *       pause: () => animation.pause(),
+ *       seek: (timeMs) => animation.goToAndStop(timeMs, false),
+ *     })),
+ * });
+ */
+export function registerAnimationDriver(driver: AnimationDriver): void {
+  globalThis.happoAnimate?.registerDriver(driver);
 }
 
 export const isHappoRun = (): boolean => globalThis.__IS_HAPPO_RUN ?? false;

--- a/src/storybook/browser/register.ts
+++ b/src/storybook/browser/register.ts
@@ -2,12 +2,20 @@ import type { Channel } from 'storybook/internal/channels';
 import type { StoryStore } from 'storybook/internal/preview-api';
 
 import type {
-  AnimateConfig,
   AnimationDriver,
   InitConfig,
   NextExampleResult,
+  StoryAnimateConfig,
   WindowHappo,
   WindowHappoAnimate,
+} from '../../isomorphic/types.ts';
+
+export type {
+  AnimateTrace,
+  AnimationDriver,
+  AnimationDriverHandle,
+  StoryAnimateConfig,
+  StoryAnimateOptions,
 } from '../../isomorphic/types.ts';
 import type { OnlyItems, SkipItems } from '../isomorphic/types.ts';
 import { SB_ROOT_ELEMENT_SELECTOR } from './constants.ts';
@@ -63,7 +71,7 @@ interface Example {
   afterScreenshot: HookFunction;
   targets: Array<string>;
   theme?: string;
-  animate: AnimateConfig | undefined;
+  animate: StoryAnimateConfig | undefined;
 }
 
 let renderTimeoutMs = 2000;
@@ -552,16 +560,23 @@ export function setShouldWaitForCompletedEvent(swfce: boolean): void {
  * that runs its own frame loop, like Lottie -- in animated snapshots. Does
  * nothing outside a Happo run, so it's safe to call from a Storybook preview.
  *
+ * `discover(root)` should return only the animations under `root`, which is
+ * how a capture is limited to part of the page.
+ *
  * @example
  * registerAnimationDriver({
  *   name: 'lottie',
- *   discover: () =>
- *     lottie.getRegisteredAnimations().map((animation) => ({
- *       target: animation,
- *       durationMs: (animation.totalFrames / animation.frameRate) * 1000,
- *       pause: () => animation.pause(),
- *       seek: (timeMs) => animation.goToAndStop(timeMs, false),
- *     })),
+ *   discover: (root) =>
+ *     lottie
+ *       .getRegisteredAnimations()
+ *       .filter((animation) => root.contains(animation.wrapper))
+ *       .map((animation) => ({
+ *         target: animation,
+ *         element: animation.wrapper,
+ *         durationMs: (animation.totalFrames / animation.frameRate) * 1000,
+ *         pause: () => animation.pause(),
+ *         seek: (timeMs) => animation.goToAndStop(timeMs, false),
+ *       })),
  * });
  */
 export function registerAnimationDriver(driver: AnimationDriver): void {

--- a/src/storybook/browser/register.ts
+++ b/src/storybook/browser/register.ts
@@ -2,6 +2,8 @@ import type { Channel } from 'storybook/internal/channels';
 import type { StoryStore } from 'storybook/internal/preview-api';
 
 import type {
+  AnimateConfig,
+  AnimateOptions,
   AnimationDriver,
   InitConfig,
   NextExampleResult,
@@ -495,7 +497,12 @@ globalThis.happo.nextExample = async (): Promise<NextExampleResult | undefined> 
       highlightsRootElement.dataset.happoIgnore = 'true';
     }
 
-    return { component, variant, waitForContent, animate };
+    return {
+      component,
+      variant,
+      waitForContent,
+      animate: withoutHooks(animate),
+    };
   } catch (e) {
     console.warn(e);
     return { component, variant };
@@ -553,6 +560,22 @@ export function setThemeSwitcher(
 
 export function setShouldWaitForCompletedEvent(swfce: boolean): void {
   shouldWaitForCompletedEvent = swfce;
+}
+
+/**
+ * A story's `animate` without its hooks, for the example result that goes to
+ * the worker. The hooks already reached the page through
+ * `happoAnimate.beforeRender()`, and functions can't travel to the worker.
+ */
+function withoutHooks(
+  animate: StoryAnimateConfig | undefined,
+): AnimateConfig | undefined {
+  if (!animate || typeof animate !== 'object') {
+    return animate;
+  }
+  return Object.fromEntries(
+    Object.entries(animate).filter(([, value]) => typeof value !== 'function'),
+  ) as AnimateOptions;
 }
 
 /**


### PR DESCRIPTION
> Stacked on #594.

## Why

happo-snap now renders a story that sets `animate` inside a motion environment, set up **before** the story renders (happo/happo-snap#1324). That covers the story's `prefersReducedMotion` override, its `setup` hook, and capture-friendly reset CSS. They have to come first because a component that checks reduced motion as it mounts, or an animation created under a zero-duration `element.animate()` shim, has already made up its mind by the time the worker looks. In the default Storybook strategy, only the client knows when a story is about to render.

## What changed

- **`register.ts`:** `nextExample()` calls `globalThis.happoAnimate.beforeRender(animate)` right before `renderStory()`, when the worker provides it. The worker decides whether the story needs an environment, and does nothing for stories that don't set `animate`.
- **`registerAnimationDriver(driver)`:** a new export from `happo/storybook/register`, and a no-op outside a Happo run. It teaches Happo to seek animations that run their own frame loop, like Lottie.
- **Types:**
  - story-level hooks: `setup`, a function form of `trigger`, and `verify(trace)`;
  - `AnimateTrace`, `AnimationDriver`, `AnimationDriverHandle` and `WindowHappoAnimate`;
  - `drivers` and `expect.drivers`.

## Testing

- `tsc --build`: clean
- `eslint` on the changed files: clean
- `node --test src/config/__tests__/loadConfig.test.ts`: 60 pass
- The `beforeRender` contract is exercised end to end in happo-snap's `animationHooks-test.js`, whose fixture's `nextExample` makes the same call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
